### PR TITLE
Always return a string for getValue when in error

### DIFF
--- a/src/BaseAPI.js
+++ b/src/BaseAPI.js
@@ -189,9 +189,14 @@ export default class BaseAPI {
       this.processListeners(callbackName, CMIElement);
     }
 
+    this.clearSCORMError(returnValue);
+
+    if (returnValue === undefined) {
+      returnValue = "";
+    }
+
     this.apiLog(callbackName, CMIElement, ': returned: ' + returnValue,
         global_constants.LOG_LEVEL_INFO);
-    this.clearSCORMError(returnValue);
 
     return returnValue;
   }


### PR DESCRIPTION
I've seen a scenario where the return value was expected to be a string (as always) in a state of error (for example BEFORE_INIT)