### PR TITLE
Potential fix for code scanning alert no. 60: Incomplete string escaping or encoding

### DIFF
--- a/dist/scorm2004.js
+++ b/dist/scorm2004.js
@@ -7384,7 +7384,7 @@ ${stackTrace}`);
       if (stringMatches(CMIElement, adlNavRequestRegex)) {
         const matches = CMIElement.match(adlNavRequestRegex);
         const request = matches[1];
-        const target = matches[2].replace("{target=", "").replace("}", "");
+        const target = matches[2].replace(/{target=/g, "").replace(/}/g, "");
         if (request === "choice" || request === "jump") {
           if (this.settings.scoItemIdValidator) {
             return String(this.settings.scoItemIdValidator(target));

--- a/src/Scorm2004API.ts
+++ b/src/Scorm2004API.ts
@@ -197,7 +197,7 @@ class Scorm2004API extends BaseAPI {
     if (stringMatches(CMIElement, adlNavRequestRegex)) {
       const matches = CMIElement.match(adlNavRequestRegex);
       const request = matches[1];
-      const target = matches[2].replace("{target=", "").replace("}", "");
+      const target = matches[2].replace(/{target=/g, "").replace(/}/g, "");
       if (request === "choice" || request === "jump") {
         if (this.settings.scoItemIdValidator) {
           return String(this.settings.scoItemIdValidator(target));


### PR DESCRIPTION
Potential fix for [https://github.com/jcputney/scorm-again/security/code-scanning/60](https://github.com/jcputney/scorm-again/security/code-scanning/60)

To fix the issue, we will use a regular expression with the global flag (`g`) to ensure that all occurrences of the substrings `"{target="` and `"}"` in `matches[2]` are replaced. This approach is more robust and handles cases where multiple occurrences of these substrings might exist. Specifically:
1. Replace `"{target="` with an empty string using a regular expression.
2. Replace `"}"` with an empty string using a regular expression.

This ensures that the entire string is sanitized correctly, regardless of the number of occurrences of the substrings.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
