### PR TITLE
Fix stringMatches bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Github Actions](https://img.shields.io/github/actions/workflow/status/jcputney/scorm-again/main.yml?style=for-the-badge "Build Status")](https://github.com/jcputney/scorm-again/actions)
 [![Codecov](https://img.shields.io/codecov/c/github/jcputney/scorm-again?style=for-the-badge "Code Coverage")](https://codecov.io/gh/jcputney/scorm-again)
-![jsDelivr hits (npm)](https://img.shields.io/jsdelivr/npm/hy/scorm-again?style=for-the-badge&label=jsDeliver%20Downloads)
+![jsDelivr hits (npm)](https://img.shields.io/jsdelivr/npm/hy/scorm-again?style=for-the-badge&label=jsDelivr%20Downloads)
 ![NPM Downloads](https://img.shields.io/npm/dy/scorm-again?style=for-the-badge&label=npm%20Downloads)
 ![npm bundle size](https://img.shields.io/bundlephobia/min/scorm-again?style=for-the-badge)
 [![npm](https://img.shields.io/npm/v/scorm-again?color=%2344cc11&style=for-the-badge)](https://www.npmjs.com/package/scorm-again)

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -534,8 +534,11 @@ export function formatMessage(functionName: string, message: string, CMIElement?
  * // Returns false (handles null gracefully)
  * stringMatches(null, "test");
  */
-export function stringMatches(str: string, tester: string): boolean {
-  return str?.match(tester) !== null;
+export function stringMatches(str: string | null | undefined, tester: string): boolean {
+  if (typeof str !== "string") {
+    return false;
+  }
+  return new RegExp(tester).test(str);
 }
 
 /**

--- a/test/utils/utilities.spec.ts
+++ b/test/utils/utilities.spec.ts
@@ -266,4 +266,18 @@ describe("Utility Tests", () => {
       });
     });
   });
+
+  describe("stringMatches()", () => {
+    it("returns true when regex matches", () => {
+      expect(Utilities.stringMatches("hello", "^he")).toBe(true);
+    });
+
+    it("returns false when regex does not match", () => {
+      expect(Utilities.stringMatches("hello", "world")).toBe(false);
+    });
+
+    it("returns false when provided value is null", () => {
+      expect(Utilities.stringMatches(null, "test")).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- handle null or undefined in `stringMatches`
- add tests for the utility
- fix the jsDelivr badge label in README

## Testing
- `npm run lint`
- `npm test`
