### PR TITLE
Fix SCORM 1.2 student response limit

### DIFF
--- a/src/constants/regex.ts
+++ b/src/constants/regex.ts
@@ -9,7 +9,14 @@ export const scorm12_regex = {
   CMIDecimal: "^-?([0-9]{0,3})(.[0-9]*)?$",
 
   CMIIdentifier: "^[\\u0021-\\u007E\\s]{0,255}$",
-  CMIFeedback: "^.{0,255}$",
+  // Allow storing larger responses for interactions
+  // Some content packages may exceed the 255 character limit
+  // defined in the SCORM 1.2 specification.  The previous
+  // expression truncated these values which resulted in
+  // a "101: General Exception" being thrown when long
+  // answers were supplied.  To support these packages we
+  // relax the limitation and accept any length string.
+  CMIFeedback: "^.*$",
   // This must be redefined
   CMIIndex: "[._](\\d+).",
   // Vocabulary Data Type Definition


### PR DESCRIPTION
## Summary
- allow long interaction feedback strings in SCORM 1.2

## Testing
- `npm test`
- `npx tsx - <<'NODE'
import {Scorm12API} from './src/Scorm12API.ts';
const api=new Scorm12API();
api.initialize();
const longStr='Ik_kan_zelfstandig_werken_aan_digitale_innovaties.____CompletelyDisagree___Ik_ben_een_leider_in_het_gebruiken_van_nieuwe_technologie.___CompletelyDisagree___Ik_zet_de_eerste_stappen_om_data_te_verzamelen_en_te_gebruiken.___CompletelyDisagree___Ik_gebruik_verschillende_digitale_systemen_die_goed_samenwerken.___CompletelyDisagree___Ik_zorg_ervoor_dat_veranderingen_ook_echt_worden_uitgevoerd.___CompletelyDisagree___Ik_heb_interesse_in_digitalisering_binnen_onze_organisatie.___CompletelyDisagree';
console.log(api.LMSSetValue('cmi.interactions.0.student_response',longStr));
console.log('errorCode',api.LMSGetLastError());
console.log('stored length',api.cmi.interactions.childArray[0]._student_response.length);
NODE