### PR TITLE
Fix CrossFrameAPI error message caching

### DIFF
--- a/src/CrossFrameAPI.ts
+++ b/src/CrossFrameAPI.ts
@@ -29,6 +29,8 @@ export default class CrossFrameAPI {
       const isInit = methodName === "Initialize" || methodName === "LMSInitialize";
       const isFinish = methodName === "Terminate" || methodName === "LMSFinish";
       const isCommit = methodName === "Commit" || methodName === "LMSCommit";
+      const isErrorString = methodName === "GetErrorString" || methodName === "LMSGetErrorString";
+      const isDiagnostic = methodName === "GetDiagnostic" || methodName === "LMSGetDiagnostic";
 
       return (...args: any[]): string => {
         // Synchronous cache update for setter calls
@@ -45,6 +47,14 @@ export default class CrossFrameAPI {
               target._cache.set(args[0], String(res));
               target._lastError = "0";
             }
+            if (isErrorString && args.length >= 1) {
+              const code = String(args[0]);
+              target._cache.set(`error_${code}`, String(res));
+            }
+            if (isDiagnostic && args.length >= 1) {
+              const code = String(args[0]);
+              target._cache.set(`diag_${code}`, String(res));
+            }
             if (methodName === "GetLastError" || methodName === "LMSGetLastError") {
               target._lastError = String(res);
             }
@@ -54,6 +64,14 @@ export default class CrossFrameAPI {
         // Return synchronously
         if (isGet && args.length >= 1) {
           return target._cache.get(args[0]) ?? "";
+        }
+        if (isErrorString && args.length >= 1) {
+          const code = String(args[0]);
+          return target._cache.get(`error_${code}`) ?? "";
+        }
+        if (isDiagnostic && args.length >= 1) {
+          const code = String(args[0]);
+          return target._cache.get(`diag_${code}`) ?? "";
         }
         if (isInit || isFinish || isCommit || isSet) {
           // Immediately return “true”


### PR DESCRIPTION
## Summary
- cache responses for GetErrorString and GetDiagnostic
- return cached error info synchronously in CrossFrameAPI

## Testing
- `npm run lint`
- `npm test`