### PR TITLE
Fix origin check in CrossFrameLMS

### DIFF
--- a/src/CrossFrameLMS.ts
+++ b/src/CrossFrameLMS.ts
@@ -18,8 +18,14 @@ export default class CrossFrameLMS {
   }
 
   private _onMessage(ev: MessageEvent) {
+    // Validate the message origin unless all origins are allowed
+    if (this._origin !== "*" && ev.origin !== this._origin) {
+      return;
+    }
+
     const msg = ev.data as MessageData;
-    if (!msg?.messageId || !msg.method) return;
+    if (!msg?.messageId || !msg.method || !ev.source) return;
+
     this._process(msg, ev.source as Window);
   }
 

--- a/test/facades/CrossFrameFacade.spec.ts
+++ b/test/facades/CrossFrameFacade.spec.ts
@@ -438,6 +438,7 @@ describe("CrossFrameLMS", () => {
         method: "LMSGetValue",
         params: ["cmi.core.lesson_status"],
       },
+      origin: "http://parent",
       source: src,
     };
 
@@ -462,6 +463,7 @@ describe("CrossFrameLMS", () => {
         method: "LMSGetValue",
         params: ["cmi.core.lesson_status"],
       },
+      origin: "http://parent",
       source: src,
     };
 
@@ -470,6 +472,7 @@ describe("CrossFrameLMS", () => {
         messageId: "42",
         params: ["cmi.core.lesson_status"],
       },
+      origin: "http://parent",
       source: src,
     };
 


### PR DESCRIPTION
## Summary
- validate `postMessage` origin in `CrossFrameLMS`
- update CrossFrameLMS tests to include message origin

## Testing
- `npm run lint`
- `npm test`