### PR TITLE
Fix CrossFrameAPI message origin handling

### DIFF
--- a/src/CrossFrameAPI.ts
+++ b/src/CrossFrameAPI.ts
@@ -134,6 +134,13 @@ export default class CrossFrameAPI {
 
   /** Handle incoming postMessage responses from the LMS frame */
   private _onMessage(ev: MessageEvent) {
+    // Validate the message origin and source unless all origins are allowed
+    if (this._origin !== "*" && ev.origin !== this._origin) {
+      return;
+    }
+    if (ev.source && ev.source !== this._targetWindow) {
+      return;
+    }
     const data = ev.data as MessageResponse;
     if (!data?.messageId) return;
     const pending = this._pending.get(data.messageId);

--- a/test/facades/CrossFrameFacade.spec.ts
+++ b/test/facades/CrossFrameFacade.spec.ts
@@ -79,6 +79,8 @@ describe("CrossFrameAPI (cache-first)", () => {
         result: "success-result",
         error: undefined,
       },
+      origin: "https://lms.example.com",
+      source: window.parent,
     };
 
     // Call _onMessage with the mock event
@@ -107,6 +109,8 @@ describe("CrossFrameAPI (cache-first)", () => {
         result: undefined,
         error: mockError,
       },
+      origin: "https://lms.example.com",
+      source: window.parent,
     };
 
     // Call _onMessage with the mock event
@@ -134,6 +138,8 @@ describe("CrossFrameAPI (cache-first)", () => {
         result: "success-result",
         error: undefined,
       },
+      origin: "https://lms.example.com",
+      source: window.parent,
     };
 
     // Call _onMessage with the mock event
@@ -152,6 +158,8 @@ describe("CrossFrameAPI (cache-first)", () => {
         result: "success-result",
         error: undefined,
       },
+      origin: "https://lms.example.com",
+      source: window.parent,
     };
 
     // Call _onMessage with the invalid event
@@ -162,6 +170,40 @@ describe("CrossFrameAPI (cache-first)", () => {
     expect(rejectSpy).not.toHaveBeenCalled();
 
     // Verify the pending request is still there
+    expect((client as any)._pending.has(messageId)).toBe(true);
+
+    // Test with a message from the wrong origin
+    const wrongOriginEvent = {
+      data: {
+        messageId,
+        result: "success-result",
+        error: undefined,
+      },
+      origin: "https://evil.example.com",
+      source: window.parent,
+    };
+
+    (client as any)._onMessage(wrongOriginEvent);
+
+    expect(resolveSpy).not.toHaveBeenCalled();
+    expect(rejectSpy).not.toHaveBeenCalled();
+    expect((client as any)._pending.has(messageId)).toBe(true);
+
+    // Test with a message from the wrong source window
+    const wrongSourceEvent = {
+      data: {
+        messageId,
+        result: "success-result",
+        error: undefined,
+      },
+      origin: "https://lms.example.com",
+      source: {} as Window,
+    };
+
+    (client as any)._onMessage(wrongSourceEvent);
+
+    expect(resolveSpy).not.toHaveBeenCalled();
+    expect(rejectSpy).not.toHaveBeenCalled();
     expect((client as any)._pending.has(messageId)).toBe(true);
   });
 


### PR DESCRIPTION
## Summary
- validate message origin and window in `CrossFrameAPI`
- adjust CrossFrame tests for new validation
- add regression tests for unexpected origin and source

## Testing
- `npm test`
- `npm run lint`
