### PR TITLE
Handle event listeners for multiple events

### DIFF
--- a/src/BaseAPI.ts
+++ b/src/BaseAPI.ts
@@ -793,7 +793,7 @@ export default abstract class BaseAPI implements IBaseAPI {
 
       let CMIElement = null;
       if (listenerSplit.length > 1) {
-        CMIElement = listenerName.replace(functionName + ".", "");
+        CMIElement = listenerFunctions[i].replace(functionName + ".", "");
       }
 
       this.listenerArray.push({
@@ -829,7 +829,7 @@ export default abstract class BaseAPI implements IBaseAPI {
 
       let CMIElement = null;
       if (listenerSplit.length > 1) {
-        CMIElement = listenerName.replace(functionName + ".", "");
+        CMIElement = listenerFunctions[i].replace(functionName + ".", "");
       }
 
       const removeIndex = this.listenerArray.findIndex(
@@ -865,7 +865,7 @@ export default abstract class BaseAPI implements IBaseAPI {
 
       let CMIElement = null;
       if (listenerSplit.length > 1) {
-        CMIElement = listenerName.replace(functionName + ".", "");
+        CMIElement = listenerFunctions[i].replace(functionName + ".", "");
       }
 
       this.listenerArray = this.listenerArray.filter(

--- a/test/Scorm12API.spec.ts
+++ b/test/Scorm12API.spec.ts
@@ -841,6 +841,51 @@ describe("SCORM 1.2 API Tests", () => {
       expect(callback3.calledTwice).toBe(true);
       expect(callback4.calledTwice).toBe(true);
     });
+
+    it("Should handle multiple events in one listener string", async () => {
+      const scorm12API = api({
+        ...DefaultSettings,
+        ...{
+          lmsCommitUrl: "/scorm12",
+          autocommit: true,
+          autocommitSeconds: 1,
+        },
+      });
+      scorm12API.lmsInitialize();
+
+      const callback = sinon.spy();
+      scorm12API.on("LMSSetValue.cmi.core.session_time CommitSuccess", callback);
+
+      scorm12API.lmsSetValue("cmi.core.session_time", "00:01:00");
+      clock.tick(2000);
+
+      await clock.runAllAsync();
+
+      expect(callback.calledTwice).toBe(true);
+    });
+
+    it("Should detach multiple events using off()", async () => {
+      const scorm12API = api({
+        ...DefaultSettings,
+        ...{
+          lmsCommitUrl: "/scorm12",
+          autocommit: true,
+          autocommitSeconds: 1,
+        },
+      });
+      scorm12API.lmsInitialize();
+
+      const callback = sinon.spy();
+      scorm12API.on("LMSSetValue.cmi.core.session_time CommitSuccess", callback);
+      scorm12API.off("LMSSetValue.cmi.core.session_time CommitSuccess", callback);
+
+      scorm12API.lmsSetValue("cmi.core.session_time", "00:01:00");
+      clock.tick(2000);
+
+      await clock.runAllAsync();
+
+      expect(callback.called).toBe(false);
+    });
     it("Should handle CommitError event", async () => {
       const scorm12API = api({
         ...DefaultSettings,

--- a/test/Scorm2004API.spec.ts
+++ b/test/Scorm2004API.spec.ts
@@ -1356,6 +1356,49 @@ describe("SCORM 2004 API Tests", () => {
       expect(callback3.calledTwice).toBe(true);
       expect(callback4.calledTwice).toBe(true);
     });
+
+    it("Should handle multiple events in one listener string", async () => {
+      const scorm2004API = api({
+        ...DefaultSettings,
+        ...{
+          lmsCommitUrl: "/scorm2004",
+          autocommit: true,
+          autocommitSeconds: 1,
+        },
+      });
+      scorm2004API.lmsInitialize();
+
+      const callback = sinon.spy();
+      scorm2004API.on("SetValue.cmi.learner_id CommitSuccess", callback);
+
+      scorm2004API.lmsSetValue("cmi.learner_id", "@jcputney");
+      scorm2004API.lmsCommit();
+      await clock.runAllAsync();
+
+      expect(callback.calledTwice).toBe(true);
+    });
+
+    it("Should detach multiple events using off()", async () => {
+      const scorm2004API = api({
+        ...DefaultSettings,
+        ...{
+          lmsCommitUrl: "/scorm2004",
+          autocommit: true,
+          autocommitSeconds: 1,
+        },
+      });
+      scorm2004API.lmsInitialize();
+
+      const callback = sinon.spy();
+      scorm2004API.on("SetValue.cmi.learner_id CommitSuccess", callback);
+      scorm2004API.off("SetValue.cmi.learner_id CommitSuccess", callback);
+
+      scorm2004API.lmsSetValue("cmi.learner_id", "@jcputney");
+      scorm2004API.lmsCommit();
+      await clock.runAllAsync();
+
+      expect(callback.called).toBe(false);
+    });
     it("Should handle CommitError event", async () => {
       const scorm2004API = api({
         ...DefaultSettings,


### PR DESCRIPTION
## Summary
- restore repo lock file state
- add unit tests covering multiple event listener strings for SCORM 1.2 and 2004 APIs

## Testing
- `npm test`
