### PR TITLE
Fix CrossFrameLMS async handling

### DIFF
--- a/src/CrossFrameLMS.ts
+++ b/src/CrossFrameLMS.ts
@@ -30,24 +30,31 @@ export default class CrossFrameLMS {
   }
 
   private _process(msg: MessageData, source: Window) {
-    let result: any, error: any;
+    const sendResponse = (result?: any, error?: { message: string; stack?: string }) => {
+      const resp: MessageResponse = { messageId: msg.messageId };
+      if (result !== undefined) resp.result = result;
+      if (error !== undefined) resp.error = error;
+      source.postMessage(resp, this._origin);
+    };
+
     try {
       const fn = (this._api as any)[msg.method];
       if (typeof fn !== "function") {
-        error = {
-          message: `Method ${msg.method} not found`,
-        };
+        sendResponse(undefined, { message: `Method ${msg.method} not found` });
+        return;
+      }
+
+      const result = fn.apply(this._api, msg.params);
+
+      if (result && typeof (result as Promise<any>).then === "function") {
+        (result as Promise<any>)
+          .then((r) => sendResponse(r))
+          .catch((e: any) => sendResponse(undefined, { message: e.message, stack: e.stack }));
       } else {
-        result = fn.apply(this._api, msg.params);
+        sendResponse(result);
       }
     } catch (e: any) {
-      error = { message: e.message, stack: e.stack };
+      sendResponse(undefined, { message: e.message, stack: e.stack });
     }
-    const resp: MessageResponse = {
-      messageId: msg.messageId,
-      result,
-      error,
-    };
-    source.postMessage(resp, this._origin);
   }
 }


### PR DESCRIPTION
## Summary
- handle async API methods in CrossFrameLMS
- avoid optional property type mismatch when posting MessageResponse

## Testing
- `npm run lint`
- `npm test`
