### PR TITLE
Fix interface typo for getCommitObject

### DIFF
--- a/src/interfaces/services.ts
+++ b/src/interfaces/services.ts
@@ -156,8 +156,14 @@ export interface ISerializationService {
     terminateCommit: boolean,
     alwaysSendTotalTime: boolean,
     renderCommonCommitFields: boolean | ((commitObject: CommitObject) => boolean),
-    renderCommitObject: (terminateCommit: boolean) => CommitObject,
-    renderCommitCMI: (terminateCommit: boolean) => StringKeyMap | Array<any>,
+    renderCommitObject: (
+      terminateCommit: boolean,
+      includeTotalTime?: boolean,
+    ) => CommitObject,
+    renderCommitCMI: (
+      terminateCommit: boolean,
+      includeTotalTime?: boolean,
+    ) => StringKeyMap | Array<any>,
     apiLogLevel: LogLevel,
   ): CommitObject | StringKeyMap | Array<any>;
 }


### PR DESCRIPTION
## Summary
- update `getCommitObject` signature in `ISerializationService` interface to include `includeTotalTime` argument

## Testing
- `npm test`