### PR TITLE
Fix getTimeAsSeconds handling of numeric strings

### DIFF
--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -170,7 +170,15 @@ export const getTimeAsSeconds = memoize(
     if (typeof timeRegex === "string") {
       timeRegex = new RegExp(timeRegex);
     }
-    if (!timeString || !timeString?.match?.(timeRegex)) {
+    if (!timeString) {
+      return 0;
+    }
+
+    if (!timeString.match(timeRegex)) {
+      // If the string represents a simple number, treat it as seconds
+      if (/^\d+(?:\.\d+)?$/.test(timeString)) {
+        return Number(timeString);
+      }
       return 0;
     }
 

--- a/test/utils/utilities.spec.ts
+++ b/test/utils/utilities.spec.ts
@@ -100,8 +100,8 @@ describe("Utility Tests", () => {
       expect(Utilities.getTimeAsSeconds("-01:00:00", scorm12_regex.CMITimespan)).toEqual(0);
     });
 
-    it("Number value returns 0", () => {
-      expect(Utilities.getTimeAsSeconds(999, scorm12_regex.CMITimespan)).toEqual(0);
+    it("Number value is treated as seconds", () => {
+      expect(Utilities.getTimeAsSeconds(999, scorm12_regex.CMITimespan)).toEqual(999);
     });
 
     it("boolean value returns 0", () => {


### PR DESCRIPTION
## Summary
- allow `getTimeAsSeconds` to interpret plain numeric strings as seconds
- update tests accordingly

## Testing
- `npm test`