### PR TITLE
Fix sequencing activity map reset

### DIFF
--- a/src/cmi/scorm2004/sequencing/activity_tree.ts
+++ b/src/cmi/scorm2004/sequencing/activity_tree.ts
@@ -36,8 +36,13 @@ export class ActivityTree extends BaseCMI {
     this._initialized = false;
     this._currentActivity = null;
     this._suspendedActivity = null;
+    // Clear the activities map so it can be rebuilt
+    this._activities.clear();
     if (this._root) {
       this._root.reset();
+      // Re-populate the activities map with the root and its children
+      this._activities.set(this._root.id, this._root);
+      this._addActivitiesToMap(this._root);
     }
   }
 

--- a/test/cmi/scorm2004/sequencing/activity_tree.spec.ts
+++ b/test/cmi/scorm2004/sequencing/activity_tree.spec.ts
@@ -68,6 +68,22 @@ describe("ActivityTree", () => {
 
       expect(rootResetSpy).toHaveBeenCalled();
     });
+
+    it("should rebuild activities map after reset", () => {
+      const activityTree = new ActivityTree();
+      const root = new Activity("root", "Root Activity");
+      const child = new Activity("child1", "Child 1");
+      root.addChild(child);
+
+      activityTree.root = root;
+      expect(activityTree.getAllActivities().length).toBe(2);
+
+      activityTree.reset();
+
+      // Activities map should still contain root and child after reset
+      expect(activityTree.getAllActivities().length).toBe(2);
+      expect(activityTree.getActivity("child1")).toBe(child);
+    });
   });
 
   describe("root", () => {


### PR DESCRIPTION
## Summary
- clear the `ActivityTree` activities map when resetting
- rebuild the map so navigation remains consistent after `reset`
- test that resetting the tree repopulates the activities map

## Testing
- `npm test`