### PR TITLE
Fix activity tree root replacement

### DIFF
--- a/src/cmi/scorm2004/sequencing/activity_tree.ts
+++ b/src/cmi/scorm2004/sequencing/activity_tree.ts
@@ -66,6 +66,8 @@ export class ActivityTree extends BaseCMI {
         scorm2004_errors.TYPE_MISMATCH,
       );
     }
+    // Clear existing map when assigning a new root to avoid stale activities
+    this._activities.clear();
     this._root = root;
     if (root) {
       this._activities.set(root.id, root);

--- a/test/cmi/scorm2004/sequencing/activity_tree.spec.ts
+++ b/test/cmi/scorm2004/sequencing/activity_tree.spec.ts
@@ -119,6 +119,27 @@ describe("ActivityTree", () => {
       expect(activityTree.getActivity("child1")).toBe(child1);
       expect(activityTree.getActivity("child2")).toBe(child2);
     });
+
+    it("should replace activities map when setting new root", () => {
+      const activityTree = new ActivityTree();
+
+      const root1 = new Activity("root1", "Root 1");
+      const child1 = new Activity("child1", "Child 1");
+      root1.addChild(child1);
+      activityTree.root = root1;
+
+      expect(activityTree.getActivity("child1")).toBe(child1);
+
+      const root2 = new Activity("root2", "Root 2");
+      const child2 = new Activity("child2", "Child 2");
+      root2.addChild(child2);
+      activityTree.root = root2;
+
+      expect(activityTree.getActivity("child1")).toBeUndefined();
+      expect(activityTree.getActivity("child2")).toBe(child2);
+      expect(activityTree.root).toBe(root2);
+      expect(activityTree.getAllActivities().length).toBe(2);
+    });
   });
 
   describe("currentActivity", () => {


### PR DESCRIPTION
## Summary
- clear activity map when assigning a new root to the activity tree
- add regression test for replacing the root

## Testing
- `npm test --silent`