### PR TITLE
Fix sequencing reset on ADLNav

### DIFF
--- a/src/cmi/scorm2004/adl.ts
+++ b/src/cmi/scorm2004/adl.ts
@@ -132,6 +132,9 @@ export class ADLNav extends BaseCMI {
   reset() {
     this._initialized = false;
     this._request = "_none_";
+    if (this._sequencing) {
+      this._sequencing.adlNav = null;
+    }
     this._sequencing = null;
     this.request_valid?.reset();
   }

--- a/test/cmi/scorm2004_adl.spec.ts
+++ b/test/cmi/scorm2004_adl.spec.ts
@@ -398,6 +398,7 @@ describe("SCORM 2004 ADL Tests", () => {
 
       nav.reset();
       expect(nav.sequencing).toBe(null);
+      expect(sequencing.adlNav).toBe(null);
       expect(nav.request).toBe("_none_");
     });
 


### PR DESCRIPTION
## Summary
- clear Sequencing.adlNav when resetting ADLNav
- test that the sequencing reference is cleared

## Testing
- `npm test --silent`