### PR TITLE
Fix AICC identifier regex

### DIFF
--- a/src/constants/regex.ts
+++ b/src/constants/regex.ts
@@ -36,7 +36,11 @@ export const scorm12_regex = {
 export const aicc_regex = {
   ...scorm12_regex,
   ...{
-    CMIIdentifier: "^\\w{1,255}$",
+    // AICC identifiers may contain letters, numbers, underscores,
+    // periods, and hyphens up to 255 characters in length.
+    // The previous expression only allowed "\w" characters which
+    // excluded periods and hyphens.
+    CMIIdentifier: "^[A-Za-z0-9._-]{1,255}$",
   },
 };
 export const scorm2004_regex = {

--- a/test/cmi/aicc_cmi.spec.ts
+++ b/test/cmi/aicc_cmi.spec.ts
@@ -73,6 +73,12 @@ describe("AICC CMI Tests", () => {
         cmi: cmi(),
         fieldName: "cmi.core.student_id",
       });
+      it("should allow hyphens and periods in student_id", () => {
+        const instance = cmi();
+        expect(() => {
+          instance.core.student_id = "student-1.id";
+        }).not.toThrow();
+      });
       h.checkReadAndWrite({
         cmi: cmi(),
         fieldName: "cmi.core.student_name",


### PR DESCRIPTION
## Summary
- correct AICC `CMIIdentifier` pattern to allow periods and hyphens
- test that dashes and periods are accepted in `cmi.core.student_id`

## Testing
- `npm test`