### PR TITLE
ci: enable Dependabot auto-merge for root npm patch/minor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,23 +1,80 @@
 ---
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# Dependabot version updates.
+# Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Auto-merge policy: the root npm devDependencies carry the "automerge" label;
+# .github/workflows/dependabot-auto-merge.yml enables GitHub auto-merge for
+# patch/minor bumps once the required "Build & Unit Tests" check passes. Major
+# bumps, docs-site, and github-actions updates are deliberately left for manual
+# review (no "automerge" label). The published package has zero runtime
+# dependencies, so the only supply-chain surface is the build/release pipeline,
+# which stays human-gated at release time. The cooldown windows give the
+# ecosystem time to yank a compromised release before Dependabot opens the PR.
 
 version: 2
 updates:
+  # Library devDependencies — the only npm deps, and none ship at runtime.
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
-    open-pull-requests-limit: 20
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "automerge"
+    cooldown:
+      default-days: 5
+      semver-major-days: 7
+      semver-minor-days: 5
+      semver-patch-days: 3
+    groups:
+      # All root deps are devDependencies, so this batches every non-major
+      # bump into one PR. Majors stay individual for manual review.
+      dev-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Docs site build tooling. Manual review: main.yml does not run on docs-site
+  # changes, so there is no functional gate to auto-merge against.
   - package-ecosystem: "npm"
     directory: "/docs-site"
     schedule:
-      interval: "daily"
-    open-pull-requests-limit: 20
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    cooldown:
+      default-days: 5
+      semver-major-days: 7
+      semver-minor-days: 5
+      semver-patch-days: 3
+    groups:
+      docs-site:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions. Manual review: a bumped action runs with workflow
+  # permissions, so these are intentionally not auto-merged. These PRs keep the
+  # SHA-pinned action references current.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
-    open-pull-requests-limit: 20
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,39 @@
+name: Dependabot auto-merge
+
+# Enables GitHub auto-merge for Dependabot pull requests that are:
+#   1. labelled "automerge" (only the root npm devDependencies carry it), and
+#   2. patch or minor bumps (majors are held for manual review).
+#
+# Auto-merge waits for the required "Build & Unit Tests" status check (set by
+# the master ruleset) before merging. The library ships zero runtime
+# dependencies, so the supply-chain surface is the build/release pipeline,
+# which stays human-gated at release time.
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    name: Auto-merge Dependabot PRs
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge (patch/minor, automerge-labelled only)
+        if: >-
+          contains(github.event.pull_request.labels.*.name, 'automerge') &&
+          (steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+           steps.meta.outputs.update-type == 'version-update:semver-minor')
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Wires up Dependabot auto-merge for the root npm devDependencies, plus general Dependabot tuning.

### Auto-merge
- New workflow `.github/workflows/dependabot-auto-merge.yml` enables GitHub auto-merge on Dependabot PRs that are **(a)** labelled `automerge` and **(b)** patch or minor bumps. It uses `dependabot/fetch-metadata` (SHA-pinned) and the official `pull_request` + `permissions` pattern; it never checks out PR code.
- Only the **root npm** ecosystem carries the `automerge` label, so only those PRs auto-merge. They merge once the required **Build & Unit Tests** check passes.

### Held for manual review (no `automerge` label)
- **Major** bumps of any ecosystem.
- **docs-site** npm — `main.yml` is path-filtered and doesn't run on docs-site changes, so there's no functional gate to auto-merge against.
- **github-actions** — a bumped action runs with workflow permissions; these stay manual and keep the SHA pins current.

### Tuning
- `cooldown` windows (patch 3d / minor 5d / major 7d) so a freshly published version isn't merged before the ecosystem can yank a compromised release.
- `groups` batches non-major root bumps into one PR.
- Schedule moved from daily to weekly.

## Companion changes (applied outside this PR)
- A `master` ruleset requiring the `Build & Unit Tests` check (the gate auto-merge waits on), with bypass for the repo owner and the GitHub Actions app (so the `finalize` dist-commit keeps working).
- An `automerge` label.

## Why this is low-risk
The published package has **zero runtime dependencies**, so consumers aren't exposed to a transitive runtime-dep compromise. The remaining supply-chain surface is the build/release pipeline, which stays human-gated (releases fire on a published GitHub Release, not on merge to master).