### PR TITLE
ci(finalize): authenticate dist-commit with DIST_COMMIT_TOKEN

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -355,6 +355,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          # Push the dist/ commit as the PAT owner (a master-ruleset bypass actor)
+          # so the required status check does not reject github-actions[bot]'s
+          # direct push. Falls back to the default token until DIST_COMMIT_TOKEN
+          # is configured, preserving current behaviour.
+          token: ${{ secrets.DIST_COMMIT_TOKEN || github.token }}
+          persist-credentials: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
Wires the `finalize` job's checkout to push the dist/ commit as the `DIST_COMMIT_TOKEN` owner (the repo owner, a ruleset bypass actor) instead of `github-actions[bot]`. This lets the dist auto-commit survive the upcoming required-status-check ruleset on master, which would otherwise reject the bot's direct push.

Uses `secrets.DIST_COMMIT_TOKEN || github.token`, so it falls back to the default token if the secret is ever absent — no behaviour change until the secret is present.

Companion to #1587 (Dependabot auto-merge wiring). The master ruleset is created after this lands.