### PR TITLE
Modernize params serialization

### DIFF
--- a/src/Scorm12API.ts
+++ b/src/Scorm12API.ts
@@ -451,18 +451,12 @@ class Scorm12API extends BaseAPI {
         this.cmi.getCurrentTotalTime();
     }
 
-    const result = [];
     const flattened: StringKeyMap = flatten(cmiExport);
     switch (this.settings.dataCommitFormat) {
       case "flattened":
         return flattened;
       case "params":
-        for (const item in flattened) {
-          if ({}.hasOwnProperty.call(flattened, item)) {
-            result.push(`${item}=${flattened[item]}`);
-          }
-        }
-        return result;
+        return Object.entries(flattened).map(([item, value]) => `${item}=${value}`);
       case "json":
       default:
         return cmiExport;

--- a/src/serialization/scorm2004_data_serializer.ts
+++ b/src/serialization/scorm2004_data_serializer.ts
@@ -80,19 +80,13 @@ export class Scorm2004DataSerializer {
       delete (cmiExport.cmi as StringKeyMap).total_time;
     }
 
-    const result = [];
     const flattened: StringKeyMap = flatten(cmiExport);
     const settings = this.context.getSettings();
     switch (settings.dataCommitFormat) {
       case "flattened":
-        return flatten(cmiExport);
+        return flattened;
       case "params":
-        for (const item in flattened) {
-          if ({}.hasOwnProperty.call(flattened, item)) {
-            result.push(`${item}=${flattened[item]}`);
-          }
-        }
-        return result;
+        return Object.entries(flattened).map(([item, value]) => `${item}=${value}`);
       case "json":
       default:
         return cmiExport;


### PR DESCRIPTION
## What changed

Replaced the older `for...in` plus `hasOwnProperty.call` loops used for `dataCommitFormat: "params"` with `Object.entries(...).map(...)` in both SCORM 1.2 and SCORM 2004 commit serialization.

Also reuses the already-computed flattened SCORM 2004 commit object instead of calling `flatten` a second time.

## Why

Remove older defensive iteration code from a small serialization path.

