### PR TITLE
ci(release): fix post-release version bump push + bump to 3.1.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,11 @@ jobs:
         uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Push the post-release version bump as the PAT owner (a master-ruleset
+          # bypass actor) so the required status check does not reject
+          # github-actions[bot]'s direct push. Falls back to the default token
+          # until DIST_COMMIT_TOKEN is configured, preserving current behaviour.
+          token: ${{ secrets.DIST_COMMIT_TOKEN || github.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scorm-again",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scorm-again",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "<8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scorm-again",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "A modern SCORM JavaScript run-time library for SCORM 1.2 and SCORM 2004",
   "main": "dist/scorm-again.js",
   "types": "index.d.ts",


### PR DESCRIPTION
The 3.1.0 release published cleanly, but the workflow's final step — committing the version bump to 3.1.1 back to master — was rejected by the master ruleset: it pushes as `github-actions[bot]` with the default token, and the Actions app cannot be a ruleset bypass actor on a user-owned repo. The same failure after 3.0.5 is why master sat at a hand-bumped 3.1.0.

Two changes:
- `release.yml`: the publish job's checkout now authenticates with `DIST_COMMIT_TOKEN` (owner PAT, a bypass actor), falling back to the default token — the exact pattern `main.yml`'s finalize job already uses for dist commits.
- Apply the bump to 3.1.1 that the 3.1.0 release could not push, so the next release doesn't collide with the published version.