### PR TITLE
ci(release): scope the version-bump PAT to the final push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,11 +106,12 @@ jobs:
         uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
-          # Push the post-release version bump as the PAT owner (a master-ruleset
-          # bypass actor) so the required status check does not reject
-          # github-actions[bot]'s direct push. Falls back to the default token
-          # until DIST_COMMIT_TOKEN is configured, preserving current behaviour.
-          token: ${{ secrets.DIST_COMMIT_TOKEN || github.token }}
+          # Do not persist checkout credentials into .git/config: this job runs
+          # third-party code (npm install lifecycle scripts, cyclonedx, npm pack)
+          # that could read them. The only later step needing git auth is the
+          # version-bump push, which sets its own scoped credentials just
+          # before pushing.
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -340,6 +341,18 @@ jobs:
         run: |
           npm version ${{ steps.next_version.outputs.next_version }} --no-git-tag-version
           echo "Updated package.json to version ${{ steps.next_version.outputs.next_version }}"
+
+      # Authenticate the version-bump push as the PAT owner (a master-ruleset
+      # bypass actor) via the remote URL, scoped to the final steps only. The
+      # PAT is deliberately NOT given to actions/checkout: persisted checkout
+      # credentials sit in .git/config while npm lifecycle scripts run, and a
+      # ruleset-bypassing PAT must not be readable there. Falls back to the
+      # default token until DIST_COMMIT_TOKEN is configured.
+      - name: Set scoped push credentials
+        env:
+          PUSH_TOKEN: ${{ secrets.DIST_COMMIT_TOKEN || github.token }}
+        run: |
+          git remote set-url origin "https://x-access-token:${PUSH_TOKEN}@github.com/${{ github.repository }}.git"
 
       # Commit version bump to master
       - name: Commit version bump


### PR DESCRIPTION
Hardening follow-up to #1616, addressing the security-review findings on it (supply-chain credential exposure / CI trust).

#1616 handed the owner PAT to `actions/checkout`, which persists it in `.git/config` for the entire publish job — including while `npm install` lifecycle scripts, `cyclonedx-npm`, and `npm pack` execute third-party code. A ruleset-bypassing PAT readable on disk during npm script execution is a supply-chain exposure (and `persist-credentials: true` would have overridden URL credentials anyway via the stored `http.extraheader`, so the push would still have gone out as `github-actions[bot]`).

This PR:
- sets `persist-credentials: false` on the publish job's checkout — no credential sits in `.git/config` while untrusted code runs; no intermediate step needs git network auth (changelog uses local `git log`, API steps use `GH_TOKEN`, npm publish uses OIDC)
- authenticates the version-bump push via a scoped `git remote set-url` with the PAT, set immediately before the commit step

Note: `main.yml`'s finalize job has the same pre-existing pattern (PAT persisted for its whole job); left untouched here, can get the same treatment separately.