### PR TITLE
fix(scorm2004): keep current activity on the exited leaf in TB.2.3

### DIFF
--- a/src/cmi/scorm2004/sequencing/handlers/termination_handler.ts
+++ b/src/cmi/scorm2004/sequencing/handlers/termination_handler.ts
@@ -290,16 +290,8 @@ export class TerminationHandler {
       }
     } while (processedExit);
 
-    // TB.2.3 step 3.6: Return sequencing request from post-condition
-    // Move to parent if no sequencing request follows (neither original nor post-condition)
-    if (!hasSequencingRequest && !postConditionResult.sequencingRequest) {
-      const current = this.activityTree.currentActivity || currentActivity;
-      if (current.parent) {
-        // Set parent as current without activating it
-        // The parent should remain inactive if it was terminated by the EXIT_PARENT cascade
-        this.activityTree.setCurrentActivityWithoutActivation(current.parent);
-      }
-    }
+    // TB.2.3 step 3.6: Return sequencing request from post-condition.
+    // Current Activity is only changed by explicit termination actions above.
 
     return {
       terminationRequest: SequencingRequestType.EXIT,

--- a/test/cmi/scorm2004/sequencing/exit_parent_state_consistency.spec.ts
+++ b/test/cmi/scorm2004/sequencing/exit_parent_state_consistency.spec.ts
@@ -64,8 +64,8 @@ describe("EXIT_PARENT State Consistency (OSP-03)", () => {
     );
   });
 
-  describe("Direct _currentActivity assignment state consistency", () => {
-    it("should properly deactivate old current activity when bypassing setter at line 674", () => {
+  describe("Plain EXIT current activity state consistency", () => {
+    it("should keep the terminated activity current when a post-condition does not trigger", () => {
       // Set up activity with post-condition that will NOT trigger
       const continueRule = grandchild1.sequencingRules.postConditionRules[0] =
         new SequencingRule(RuleActionType.CONTINUE);
@@ -76,8 +76,7 @@ describe("EXIT_PARENT State Consistency (OSP-03)", () => {
       child1.isActive = true;
       grandchild1.isCompleted = false; // Post-condition won't trigger
 
-      // Navigation request is just EXIT with no sequencing
-      // This will hit the code path at line 674 where _currentActivity is set directly
+      // Navigation request is just EXIT with no sequencing.
       const result = overallProcess.processNavigationRequest(NavigationRequestType.EXIT);
 
       expect(result.valid).toBe(true);
@@ -85,19 +84,17 @@ describe("EXIT_PARENT State Consistency (OSP-03)", () => {
       // The old current activity (grandchild1) should be deactivated
       expect(grandchild1.isActive).toBe(false);
 
-      // The parent (child1) becomes the new current activity
-      expect(activityTree.currentActivity).toBe(child1);
+      // Current activity remains the just-ended activity.
+      expect(activityTree.currentActivity).toBe(grandchild1);
 
-      // Key test: child1 SHOULD remain active because it was already active as an ancestor
-      // The method preserves the active state of the new current and shared ancestors
+      // Ancestors remain active because they were already active.
       expect(child1.isActive).toBe(true);
 
       // Root should also remain active (shared ancestor)
       expect(root.isActive).toBe(true);
     });
 
-    it("should maintain consistent state after EXIT with post-condition that doesn't trigger", () => {
-      // This test verifies that the direct _currentActivity assignment doesn't break state
+    it("should maintain consistent state after EXIT with no sequencing request", () => {
       activityTree.currentActivity = grandchild1;
       grandchild1.isActive = true;
       child1.isActive = true;
@@ -107,17 +104,14 @@ describe("EXIT_PARENT State Consistency (OSP-03)", () => {
 
       expect(result.valid).toBe(true);
       expect(grandchild1.isActive).toBe(false);
-      expect(activityTree.currentActivity).toBe(child1);
+      expect(activityTree.currentActivity).toBe(grandchild1);
 
       // Child1 and root remain active (they were already active as ancestors)
-      // The method preserves their state since they're ancestors of the new current
       expect(child1.isActive).toBe(true);
       expect(root.isActive).toBe(true);
     });
 
-    it("should handle null parent when bypassing setter", () => {
-      // Edge case: what if current.parent is null but we try to set it?
-      // This shouldn't happen in practice due to the if (current.parent) check
+    it("should handle EXIT at root as session exit", () => {
       activityTree.currentActivity = root;
       root.isActive = true;
 
@@ -129,29 +123,22 @@ describe("EXIT_PARENT State Consistency (OSP-03)", () => {
       expect(activityTree.currentActivity).toBeNull();
     });
 
-    it("should properly handle subsequent navigation after direct assignment", () => {
-      // Set up initial state where we'll hit the direct assignment path
+    it("should allow subsequent continue navigation after plain EXIT", () => {
       activityTree.currentActivity = grandchild1;
       grandchild1.isActive = true;
       child1.isActive = true;
 
-      // First EXIT - will use setCurrentActivityWithoutActivation to set currentActivity to child1
       const result1 = overallProcess.processNavigationRequest(NavigationRequestType.EXIT);
       expect(result1.valid).toBe(true);
-      expect(activityTree.currentActivity).toBe(child1);
-      expect(child1.isActive).toBe(true); // Remains active (was already active as ancestor)
+      expect(activityTree.currentActivity).toBe(grandchild1);
 
-      // Now verify we can still navigate correctly from this state
-      // This tests that the direct assignment didn't break the activity tree state
-      activityTree.currentActivity = null; // Reset session
-
-      const result2 = overallProcess.processNavigationRequest(NavigationRequestType.START);
+      const result2 = overallProcess.processNavigationRequest(NavigationRequestType.CONTINUE);
       expect(result2.valid).toBe(true);
-      // Should be able to start fresh
+      expect(result2.targetActivity).toBe(grandchild2);
     });
 
     it("should compare behavior: setter activation vs direct assignment", () => {
-      // Test 1: Normal setter behavior (like line 634)
+      // Test 1: Normal setter behavior
       activityTree.currentActivity = grandchild1;
       grandchild1.isActive = true;
       child1.isActive = false;
@@ -162,7 +149,7 @@ describe("EXIT_PARENT State Consistency (OSP-03)", () => {
       expect(child1.isActive).toBe(true); // Setter activates
       expect(root.isActive).toBe(true); // Setter activates ancestors
 
-      // Test 2: Direct assignment behavior (like line 674)
+      // Test 2: Direct assignment behavior
       activityTree.currentActivity = grandchild1;
       grandchild1.isActive = true;
       child1.isActive = false;
@@ -212,9 +199,9 @@ describe("EXIT_PARENT State Consistency (OSP-03)", () => {
       expect(root.isActive).toBe(true); // Still active (shared ancestor)
     });
 
-    it("should demonstrate the problem direct assignment is trying to solve", () => {
-      // Scenario: We've terminated an activity and want to set parent as current
-      // but we DON'T want to activate the parent (it was also terminated)
+    it("should demonstrate the non-activating current activity helper", () => {
+      // Scenario: a sequencing action needs to set a new current activity
+      // without activating that activity or its ancestors.
 
       activityTree.currentActivity = grandchild1;
       grandchild1.isActive = true;
@@ -223,12 +210,11 @@ describe("EXIT_PARENT State Consistency (OSP-03)", () => {
       // Terminate grandchild1
       grandchild1.isActive = false;
 
-      // Now we want to set child1 as current WITHOUT activating it
+      // Now we want to set child1 as current WITHOUT activating it.
       // If we use the setter:
       // activityTree.currentActivity = child1;
       // This would activate child1 and root, which is wrong after termination
 
-      // So we use the dedicated method:
       activityTree.setCurrentActivityWithoutActivation(child1);
 
       // Verify: child1 is current and REMAINS active (it was already active)
@@ -239,9 +225,7 @@ describe("EXIT_PARENT State Consistency (OSP-03)", () => {
   });
 
   describe("Alternative solutions to direct assignment", () => {
-    it("should verify if ActivityTree needs a setCurrentActivityWithoutActivation method", () => {
-      // This test demonstrates what a proper method might look like
-
+    it("should demonstrate the deactivation logic needed by non-activating assignment", () => {
       // Current state
       activityTree.currentActivity = grandchild1;
       expect(grandchild1.isActive).toBe(true);
@@ -273,62 +257,32 @@ describe("EXIT_PARENT State Consistency (OSP-03)", () => {
     });
   });
 
-  describe("Impact analysis: does direct assignment cause bugs?", () => {
-    it("should check if old currentActivity is properly deactivated before direct assignment", () => {
-      // Set up the exact scenario from line 674
+  describe("Impact analysis: non-activating current activity assignment", () => {
+    it("should preserve old current deactivation when setting current without activation", () => {
       activityTree.currentActivity = grandchild1;
       grandchild1.isActive = true;
       child1.isActive = true;
 
-      // Before line 674 executes, grandchild1 has already been deactivated
-      // by endAttemptProcess (line 582)
-      grandchild1.isActive = false; // This happens in endAttemptProcess
+      grandchild1.isActive = false;
+      activityTree.setCurrentActivityWithoutActivation(child1);
 
-      // Now the direct assignment happens (line 674)
-      const current = grandchild1;
-      if (current.parent) {
-        (activityTree as any)._currentActivity = current.parent;
-      }
-
-      // The question: is the old currentActivity (grandchild1) still in the correct state?
-      // Yes, because it was already deactivated by endAttemptProcess
       expect(grandchild1.isActive).toBe(false);
       expect(activityTree.currentActivity).toBe(child1);
-
-      // But what about child1's previous active state?
-      // It's currently true, but we're setting it as current WITHOUT activation
-      // This could be inconsistent
-      expect(child1.isActive).toBe(true); // Still active from before
+      expect(child1.isActive).toBe(true);
     });
 
-    it("should verify the actual state in the TB.2.3 step 3.6 scenario", () => {
-      // This simulates the exact conditions when line 674 is reached:
-      // 1. EXIT has been processed
-      // 2. No sequencing request follows
-      // 3. We want to set parent as current without activating it
-
-      // Initial state
+    it("should verify the actual state after plain EXIT with no sequencing request", () => {
       activityTree.currentActivity = grandchild1;
       grandchild1.isActive = true;
       child1.isActive = true;
       root.isActive = true;
 
-      // TB.2.3 step 3.1: endAttemptProcess deactivates grandchild1
-      grandchild1.isActive = false;
+      const result = overallProcess.processNavigationRequest(NavigationRequestType.EXIT);
 
-      // TB.2.3 step 3.6: Set parent as current without activating
-      const current = grandchild1;
-      if (current.parent) {
-        (activityTree as any)._currentActivity = current.parent;
-      }
-
-      // State check:
-      expect(activityTree.currentActivity).toBe(child1);
-      expect(grandchild1.isActive).toBe(false); // Correctly deactivated
-
-      // The issue: child1 is still active, but it SHOULD be inactive
-      // because we're exiting from it without a sequencing request
-      expect(child1.isActive).toBe(true); // This is potentially wrong!
+      expect(result.valid).toBe(true);
+      expect(activityTree.currentActivity).toBe(grandchild1);
+      expect(grandchild1.isActive).toBe(false);
+      expect(child1.isActive).toBe(true);
     });
   });
 });

--- a/test/cmi/scorm2004/sequencing/logout_exit_handling.spec.ts
+++ b/test/cmi/scorm2004/sequencing/logout_exit_handling.spec.ts
@@ -127,6 +127,7 @@ describe("Logout Exit Handling (REQ-NAV-025)", () => {
         "normal"
       );
       expect(normalResult.valid).toBe(true);
+      expect(activityTree.currentActivity).toBe(lesson1);
 
       // Reset for logout test
       activityTree.currentActivity = lesson1;

--- a/test/cmi/scorm2004/sequencing/overall_sequencing_process.spec.ts
+++ b/test/cmi/scorm2004/sequencing/overall_sequencing_process.spec.ts
@@ -844,7 +844,8 @@ describe("Overall Sequencing Process (OP.1)", () => {
 
       // Should perform normal exit (not exit all)
       expect(result.valid).toBe(true);
-      // Current activity should change but session shouldn't completely end
+      // Current activity remains the just-ended activity, and the session does not completely end.
+      expect(activityTree.currentActivity).toBe(grandchild1);
       expect(grandchild1.isActive).toBe(false);
     });
 

--- a/test/cmi/scorm2004/sequencing/termination_post_condition_loop.spec.ts
+++ b/test/cmi/scorm2004/sequencing/termination_post_condition_loop.spec.ts
@@ -102,8 +102,8 @@ describe("Post-Condition Loop in Termination Request Process", () => {
       // Verify the post-condition EXIT_PARENT caused level2 to also be terminated
       expect(level2.isActive).toBe(false);
 
-      // Verify we're now at level1 (parent of level2)
-      expect(activityTree.currentActivity).toBe(level1);
+      // Verify we're now at level2, the parent explicitly exited by EXIT_PARENT.
+      expect(activityTree.currentActivity).toBe(level2);
     });
 
     it("should end attempt on parent activity when EXIT_PARENT is processed", () => {
@@ -154,8 +154,8 @@ describe("Post-Condition Loop in Termination Request Process", () => {
       expect(level2.isActive).toBe(false);
       expect(level1.isActive).toBe(false);
 
-      // Should now be at root
-      expect(activityTree.currentActivity).toBe(root);
+      // Should now be at level1, the last ancestor explicitly exited by EXIT_PARENT.
+      expect(activityTree.currentActivity).toBe(level1);
     });
 
     it("should cascade through 3 levels with chained EXIT_PARENT", () => {
@@ -318,7 +318,6 @@ describe("Post-Condition Loop in Termination Request Process", () => {
     it("should evaluate RETRY post-condition after termination", () => {
       // Setup: Activity with RETRY post-condition at root level
       // Testing at root, post-condition sequencing requests are actually processed
-      // and RETRY from a child would fail because currentActivity moves to parent after termination
       const retryRule = new SequencingRule(RuleActionType.RETRY);
       retryRule.addCondition(new RuleCondition(RuleConditionType.COMPLETED));
       root.sequencingRules.addPostConditionRule(retryRule);
@@ -480,8 +479,8 @@ describe("Post-Condition Loop in Termination Request Process", () => {
       // level2 should still be active (no cascade)
       expect(level2.isActive).toBe(true);
 
-      // Current activity should move to parent
-      expect(activityTree.currentActivity).toBe(level2);
+      // Current activity remains the terminated activity.
+      expect(activityTree.currentActivity).toBe(level3);
     });
 
     it("should handle partial cascade when post-condition chain ends", () => {
@@ -511,8 +510,8 @@ describe("Post-Condition Loop in Termination Request Process", () => {
       // level1 should still be active (cascade stopped)
       expect(level1.isActive).toBe(true);
 
-      // Current activity should be at level1
-      expect(activityTree.currentActivity).toBe(level1);
+      // Current activity remains the last activity explicitly exited by EXIT_PARENT.
+      expect(activityTree.currentActivity).toBe(level2);
     });
   });
 
@@ -541,8 +540,8 @@ describe("Post-Condition Loop in Termination Request Process", () => {
       // level2 should still be active (post-condition didn't match)
       expect(level2.isActive).toBe(true);
 
-      // Current activity should move to parent
-      expect(activityTree.currentActivity).toBe(level2);
+      // Current activity remains the terminated activity because EXIT_PARENT did not trigger.
+      expect(activityTree.currentActivity).toBe(level3);
     });
 
     it("should handle RETRY at root correctly", () => {

--- a/test/cmi/scorm2004/sequencing/termination_request_process.spec.ts
+++ b/test/cmi/scorm2004/sequencing/termination_request_process.spec.ts
@@ -399,7 +399,7 @@ describe("Termination Request Process (TB.2.3)", () => {
       expect(result.valid).toBe(true);
       expect(grandchild1.isActive).toBe(false);
       expect(grandchild1.isSuspended).toBe(false);
-      expect(activityTree.currentActivity).toBe(child1); // Should move to parent
+      expect(activityTree.currentActivity).toBe(grandchild1);
     });
 
     it("should maintain consistent state after SUSPEND", () => {
@@ -448,6 +448,48 @@ describe("Termination Request Process (TB.2.3)", () => {
   });
 
   describe("Exit Type Handling (cmi.exit)", () => {
+    it("should keep the current leaf after normal exit so continue can flow to the next sibling", () => {
+      const flatTree = new ActivityTree();
+      const flatRoot = new Activity("root", "Course");
+      const activity1 = new Activity("activity_1", "Activity 1");
+      const activity2 = new Activity("activity_2", "Activity 2");
+      const activity3 = new Activity("activity_3", "Activity 3");
+
+      flatRoot.addChild(activity1);
+      flatRoot.addChild(activity2);
+      flatRoot.addChild(activity3);
+      flatRoot.sequencingControls.flow = true;
+      flatTree.root = flatRoot;
+
+      const flatSequencingProcess = new SequencingProcess(flatTree);
+      const flatRollupProcess = new RollupProcess();
+      const flatOverallProcess = new OverallSequencingProcess(
+        flatTree,
+        flatSequencingProcess,
+        flatRollupProcess
+      );
+
+      flatTree.currentActivity = activity1;
+      activity1.isActive = true;
+
+      const exitResult = flatOverallProcess.processNavigationRequest(
+        NavigationRequestType.EXIT,
+        null,
+        "normal"
+      );
+
+      expect(exitResult.valid).toBe(true);
+      expect(activity1.isActive).toBe(false);
+      expect(flatTree.currentActivity).toBe(activity1);
+
+      const continueResult = flatOverallProcess.processNavigationRequest(
+        NavigationRequestType.CONTINUE
+      );
+
+      expect(continueResult.valid).toBe(true);
+      expect(continueResult.targetActivity).toBe(activity2);
+    });
+
     it("should handle logout exit type and terminate all activities", () => {
       activityTree.currentActivity = grandchild1;
       grandchild1.isActive = true;
@@ -484,7 +526,7 @@ describe("Termination Request Process (TB.2.3)", () => {
       expect(result.valid).toBe(true);
       // Normal exit should just exit current activity
       expect(grandchild1.isActive).toBe(false);
-      expect(activityTree.currentActivity).toBe(child1);
+      expect(activityTree.currentActivity).toBe(grandchild1);
     });
 
     it("should handle suspend exit type (note: exitType is informational)", () => {
@@ -503,7 +545,7 @@ describe("Termination Request Process (TB.2.3)", () => {
       // EXIT with exitType="suspend" still performs normal exit
       // To actually suspend, use SUSPEND_ALL navigation request
       expect(grandchild1.isActive).toBe(false);
-      expect(activityTree.currentActivity).toBe(child1);
+      expect(activityTree.currentActivity).toBe(grandchild1);
     });
 
     it("should handle empty exit type as normal exit", () => {
@@ -520,7 +562,7 @@ describe("Termination Request Process (TB.2.3)", () => {
       expect(result.valid).toBe(true);
       // Empty exit should behave like normal exit
       expect(grandchild1.isActive).toBe(false);
-      expect(activityTree.currentActivity).toBe(child1);
+      expect(activityTree.currentActivity).toBe(grandchild1);
     });
   });
 
@@ -563,9 +605,9 @@ describe("Termination Request Process (TB.2.3)", () => {
       // Navigation request is just EXIT with no sequencing
       const result = overallProcess.processNavigationRequest(NavigationRequestType.EXIT);
 
-      // Should just exit to parent without continuing
+      // Should just exit without continuing
       expect(result.valid).toBe(true);
-      expect(activityTree.currentActivity).toBe(child1);
+      expect(activityTree.currentActivity).toBe(grandchild1);
     });
   });
 
@@ -940,7 +982,7 @@ describe("Termination Request Process (TB.2.3)", () => {
       expect(grandchild2.isActive).toBe(false);
     });
 
-    it("should handle termination when parent becomes current after EXIT", () => {
+    it("should keep the terminated activity current after EXIT", () => {
       activityTree.currentActivity = grandchild1;
       grandchild1.isActive = true;
       child1.isActive = false; // Parent not active
@@ -949,14 +991,13 @@ describe("Termination Request Process (TB.2.3)", () => {
 
       expect(result.valid).toBe(true);
       expect(grandchild1.isActive).toBe(false);
-      // Parent should become current but remain inactive
-      expect(activityTree.currentActivity).toBe(child1);
+      expect(activityTree.currentActivity).toBe(grandchild1);
       expect(child1.isActive).toBe(false);
     });
   });
 
   describe("Termination with Sequencing Requests", () => {
-    it("should not move to parent when EXIT has sequencing request following", () => {
+    it("should process post-condition sequencing requests after EXIT", () => {
       activityTree.currentActivity = grandchild1;
       grandchild1.isActive = true;
 
@@ -970,19 +1011,17 @@ describe("Termination Request Process (TB.2.3)", () => {
 
       const result = overallProcess.processNavigationRequest(NavigationRequestType.EXIT);
 
-      // With CONTINUE post-condition, should attempt to continue
+      // With CONTINUE post-condition, should attempt to continue.
       if (result.valid) {
-        // Should not just move to parent; should try to find next activity
+        // Should not just stay on the exited activity; should try to find next activity.
         expect(activityTree.currentActivity).not.toBe(child1);
       }
     });
 
-    it("should not move to parent when ABANDON has sequencing request following", () => {
+    it("should move to parent when ABANDON has no sequencing request following", () => {
       activityTree.currentActivity = grandchild1;
       grandchild1.isActive = true;
 
-      // ABANDON doesn't support post-conditions in SCORM spec
-      // But the hasSequencingRequest parameter prevents parent movement
       const result = overallProcess.processNavigationRequest(NavigationRequestType.ABANDON);
 
       expect(result.valid).toBe(true);


### PR DESCRIPTION
## Bug

The exit case of the Termination Request Process (`termination_handler.ts`) promoted the Current Activity to its parent whenever a plain exit produced no post-condition sequencing request:

```ts
if (!hasSequencingRequest && !postConditionResult.sequencingRequest) {
  const current = this.activityTree.currentActivity || currentActivity;
  if (current.parent) {
    this.activityTree.setCurrentActivityWithoutActivation(current.parent);
  }
}
```

IMS SS TB.2.3 has no such step — step 3.6 only returns the post-condition rule's sequencing request. The Current Activity is moved only by explicit rule outcomes (EXIT_PARENT cascade, EXIT_ALL), delivery (DB.2), or session end.

## Impact

In any flat activity tree the promotion lands on the **root**. After the first SCO terminates with `cmi.exit=normal`, every subsequent `continue`/`previous` navigation request fails **NB.2.1-5** (the root has no parent whose flow controls could authorize it) — all relative navigation is permanently dead after one activity. Multi-SCO manual-navigation courses cannot advance past their first activity.

Reproduced end-to-end with the ADL SCORM 2004 4th Ed CTS **SX-02** package driven through a real LMS player integration: activity_1 runs green, `Terminate('')` returns true, then `getCurrentActivity()` is the root and `processNavigationRequest('continue')` returns false with exception NB.2.1-5.

## Lineage

The block dates to the post-condition-loop work (79f018e9, refined 79e66bf9, softened to `setCurrentActivityWithoutActivation` in aff5cd9f, carried into `TerminationHandler` by #1318). The legitimate EXIT_PARENT movement it accompanied is handled separately (and correctly) earlier in the same function; several specs asserted the promotion and thereby encoded the bug — they now assert the spec behavior.

## Fix

Remove the promotion; TB.2.3 step 3.6 now only returns the post-condition sequencing request. New flat-tree regression pins it: normal EXIT leaves activity_1 current, and a following CONTINUE identifies activity_2 for delivery.

## Verification

- Regression is RED against the previous handler (7 failures), GREEN with the fix.
- All touched spec files: 401/401.
- Full suite: **189 files, 6796/6796 passing**.