### PR TITLE
fix(cmi): clear session start time on reset so a reused API can re-initialize

### DIFF
--- a/src/cmi/scorm12/cmi.ts
+++ b/src/cmi/scorm12/cmi.ts
@@ -61,6 +61,7 @@ export class CMI extends BaseRootCMI {
    */
   reset(): void {
     this._initialized = false;
+    this._start_time = undefined;
 
     this._launch_data = "";
     this._comments = "";

--- a/src/cmi/scorm2004/cmi.ts
+++ b/src/cmi/scorm2004/cmi.ts
@@ -107,6 +107,7 @@ export class CMI extends BaseRootCMI {
    */
   reset() {
     this._initialized = false;
+    this._start_time = undefined;
 
     // Reset new component classes
     this.metadata?.reset();

--- a/test/api/Scorm12API.spec.ts
+++ b/test/api/Scorm12API.spec.ts
@@ -486,6 +486,31 @@ describe("SCORM 1.2 API Tests", () => {
     });
   });
 
+  describe("reset()", () => {
+    it("should allow self-reported session time to initialize again after reset", (): void => {
+      const getTimeSpy = vi
+        .spyOn(Date.prototype, "getTime")
+        .mockReturnValueOnce(1000)
+        .mockReturnValueOnce(2000);
+
+      try {
+        const scorm12API = api({ selfReportSessionTime: true });
+
+        expect(scorm12API.LMSInitialize("")).toBe("true");
+        const firstStartTime = scorm12API.cmi.start_time;
+        expect(firstStartTime).toBe(1000);
+
+        scorm12API.reset();
+
+        expect(() => scorm12API.LMSInitialize("")).not.toThrow();
+        expect(scorm12API.cmi.start_time).toBe(2000);
+        expect(scorm12API.cmi.start_time).not.toBe(firstStartTime);
+      } finally {
+        getTimeSpy.mockRestore();
+      }
+    });
+  });
+
   describe("renderCommitCMI()", () => {
     it("should calculate total time when terminateCommit passed", () => {
       const scorm12API = api();

--- a/test/api/Scorm2004API.spec.ts
+++ b/test/api/Scorm2004API.spec.ts
@@ -721,6 +721,29 @@ describe("SCORM 2004 API Tests", () => {
 
       expect(commonResetSpy).toHaveBeenCalledOnce();
     });
+
+    it("should allow self-reported session time to initialize again after reset", (): void => {
+      const getTimeSpy = vi
+        .spyOn(Date.prototype, "getTime")
+        .mockReturnValueOnce(1000)
+        .mockReturnValueOnce(2000);
+
+      try {
+        const scorm2004API = basicApi({ selfReportSessionTime: true });
+
+        expect(scorm2004API.Initialize("")).toBe("true");
+        const firstStartTime = scorm2004API.cmi.start_time;
+        expect(firstStartTime).toBe(1000);
+
+        scorm2004API.reset();
+
+        expect(() => scorm2004API.Initialize("")).not.toThrow();
+        expect(scorm2004API.cmi.start_time).toBe(2000);
+        expect(scorm2004API.cmi.start_time).not.toBe(firstStartTime);
+      } finally {
+        getTimeSpy.mockRestore();
+      }
+    });
   });
 
   describe("Scorm2004API.Finish", () => {

--- a/test/cmi/scorm12_cmi_reset.spec.ts
+++ b/test/cmi/scorm12_cmi_reset.spec.ts
@@ -12,6 +12,17 @@ describe("SCORM 1.2 CMI Reset Tests", () => {
       expect((cmi as any)._initialized).toBe(false);
     });
 
+    it("should clear the self-reported session start time", () => {
+      const cmi = new CMI();
+      cmi.setStartTime();
+
+      expect(cmi.start_time).toBeDefined();
+
+      cmi.reset();
+
+      expect(cmi.start_time).toBeUndefined();
+    });
+
     it("should clear launch_data and comments on reset", () => {
       const cmi = new CMI();
 

--- a/test/cmi/scorm2004_cmi_reset.spec.ts
+++ b/test/cmi/scorm2004_cmi_reset.spec.ts
@@ -17,6 +17,17 @@ describe("SCORM 2004 CMI Reset Tests", () => {
       expect((cmi as any)._initialized).toBe(false);
     });
 
+    it("should clear the self-reported session start time", () => {
+      const cmi = new CMI();
+      cmi.setStartTime();
+
+      expect(cmi.start_time).toBeDefined();
+
+      cmi.reset();
+
+      expect(cmi.start_time).toBeUndefined();
+    });
+
     it("should keep learner information but reset status information", () => {
       const cmi = new CMI();
 


### PR DESCRIPTION
## Bug

With `selfReportSessionTime: true`, `BaseAPI.initialize()` calls `setStartTime()`, which throws `Start time has already been set.` when `_start_time` is defined. The SCORM 2004 and SCORM 1.2 root CMI `reset()` implementations — whose own doc comments cite the DB.2 between-SCO reset — clear `_initialized` and all sub-components but never `_start_time`.

## Impact

Any multi-activity course that reuses one API instance across SCOs (reset → next SCO initializes) throws on the second `Initialize('')`; the session never opens and every subsequent call fails 122/132/112. Reproduced with the ADL SCORM 2004 4th Ed CTS SX-02 package through a real LMS sequenced player (follow-on to #1631: with navigation fixed, activity_3 delivers and its Initialize throws exactly this error).

## Fix

Clear `_start_time` in both root CMI `reset()` implementations (direct field access, matching the existing idiom). The double-set guard in `setStartTime()` is intentionally untouched — genuine double-Initialize within one session still throws, and its existing test still passes.

## Verification

- New CMI-level and API-level regressions for both SCORM 2004 and SCORM 1.2: RED against master (4 failures), GREEN with the fix.
- Full suite: **189 files, 6800/6800 passing**.