### PR TITLE
ci(release): discard dist/ before the version-bump commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -354,6 +354,14 @@ jobs:
         run: |
           git remote set-url origin "https://x-access-token:${PUSH_TOKEN}@github.com/${{ github.repository }}.git"
 
+      # The artifact download leaves dist/ differing from the tag's committed
+      # dist, and git-auto-commit's internal checkout of master refuses to
+      # proceed over a dirty tree ("would be overwritten by checkout" — this
+      # broke the 3.1.2 release's bump). Only package.json/package-lock.json
+      # belong in the bump commit, so discard everything else first.
+      - name: Discard build artifacts before bump commit
+        run: git checkout -- dist/ || true
+
       # Commit version bump to master
       - name: Commit version bump
         uses: stefanzweifel/git-auto-commit-action@v7.2.0


### PR DESCRIPTION
The 3.1.2 release published to npm fine but its final **Commit version bump** step failed: the job downloads built artifacts into `dist/`, and when they differ from the tag's committed dist, git-auto-commit's internal `git checkout master` refuses over the dirty tree (`error: Your local changes to the following files would be overwritten by checkout: dist/esm/...`). 3.1.1 only survived because its rebuilt dist happened to match byte-for-byte.

Only `package.json`/`package-lock.json` belong in the bump commit (`file_pattern` already scopes it), so this restores `dist/` right before the auto-commit step, making the bump deterministic.

The missed 3.1.3 bump itself is remediated separately.