### PR TITLE
[skip ci] Bump version to 3.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scorm-again",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scorm-again",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "license": "MIT",
       "devDependencies": {
         "@cyclonedx/cyclonedx-npm": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scorm-again",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "A modern SCORM JavaScript run-time library for SCORM 1.2 and SCORM 2004",
   "main": "dist/scorm-again.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Manual remediation of the 3.1.2 release's failed **Commit version bump** step (see #1637 for the workflow fix): the post-release bump to 3.1.3 never landed on master, so `package.json` still reads 3.1.2. Same commit the release job would have produced (`npm version 3.1.3 --no-git-tag-version`).