### PR TITLE
Honor completionThreshold and ancestor exit rules in SCORM 2004 sequencing

### DIFF
--- a/src/Scorm2004API.ts
+++ b/src/Scorm2004API.ts
@@ -239,7 +239,29 @@ class Scorm2004API extends BaseAPI {
     this.commonReset(settings);
 
     this.cmi?.reset();
+    this.applyCurrentActivityLaunchData();
     this.adl?.reset();
+  }
+
+  /**
+   * Apply launch-static activity data to CMI while the new SCO is pre-initialize.
+   *
+   * @spec SCORM 2004 4th Ed. RTE 4.2.9 - cmi.completion_threshold
+   */
+  private applyCurrentActivityLaunchData(): void {
+    const currentActivity = this._sequencing?.getCurrentActivity();
+    if (!this.cmi || !currentActivity) {
+      return;
+    }
+
+    const contentActivityData =
+      this._sequencing.overallSequencingProcess?.getContentActivityData(currentActivity);
+    const completionThreshold =
+      contentActivityData?.completionThreshold ??
+      currentActivity.completionThreshold?.toString() ??
+      "";
+
+    this.cmi.completion_threshold = completionThreshold;
   }
 
   /**
@@ -853,14 +875,16 @@ class Scorm2004API extends BaseAPI {
       if (this.cmi.mode === "normal") {
         if (this.cmi.credit === "credit") {
           if (this.cmi.completion_threshold && this.cmi.progress_measure) {
-            if (this.cmi.progress_measure >= this.cmi.completion_threshold) {
+            if (
+              parseFloat(this.cmi.progress_measure) >= parseFloat(this.cmi.completion_threshold)
+            ) {
               this.cmi.completion_status = "completed";
             } else {
               this.cmi.completion_status = "incomplete";
             }
           }
           if (this.cmi.scaled_passing_score && this.cmi.score.scaled) {
-            if (this.cmi.score.scaled >= this.cmi.scaled_passing_score) {
+            if (parseFloat(this.cmi.score.scaled) >= parseFloat(this.cmi.scaled_passing_score)) {
               this.cmi.success_status = "passed";
             } else {
               this.cmi.success_status = "failed";

--- a/src/cmi/scorm2004/completion_status_evaluation.ts
+++ b/src/cmi/scorm2004/completion_status_evaluation.ts
@@ -1,0 +1,42 @@
+import { CompletionStatus } from "../../constants/enums";
+
+export type CompletionStatusThresholdInput = {
+  completionThreshold?: number | string | null | undefined;
+  progressMeasure?: number | string | null | undefined;
+  storedCompletionStatus?: string | null | undefined;
+};
+
+/**
+ * Evaluate cmi.completion_status from completion_threshold and progress_measure.
+ *
+ * @spec SCORM 2004 4th Ed. RTE 4.2.4.1a / RTE 4.2.9
+ */
+export function evaluateCompletionStatusFromThreshold({
+  completionThreshold,
+  progressMeasure,
+  storedCompletionStatus,
+}: CompletionStatusThresholdInput): string {
+  if (
+    completionThreshold !== "" &&
+    completionThreshold !== null &&
+    completionThreshold !== undefined
+  ) {
+    const thresholdValue = parseFloat(String(completionThreshold));
+
+    if (!isNaN(thresholdValue)) {
+      if (progressMeasure !== "" && progressMeasure !== null && progressMeasure !== undefined) {
+        const progressValue = parseFloat(String(progressMeasure));
+
+        if (!isNaN(progressValue)) {
+          return progressValue >= thresholdValue
+            ? CompletionStatus.COMPLETED
+            : CompletionStatus.INCOMPLETE;
+        }
+      }
+
+      return CompletionStatus.UNKNOWN;
+    }
+  }
+
+  return storedCompletionStatus || CompletionStatus.UNKNOWN;
+}

--- a/src/cmi/scorm2004/sequencing/handlers/rte_data_transfer.ts
+++ b/src/cmi/scorm2004/sequencing/handlers/rte_data_transfer.ts
@@ -1,5 +1,6 @@
 import { Activity } from "../activity";
 import { CompletionStatus, SuccessStatus } from "../../../../constants/enums";
+import { evaluateCompletionStatusFromThreshold } from "../../completion_status_evaluation";
 
 /**
  * Interface for CMI data provided for RTE data transfer
@@ -156,11 +157,45 @@ export class RteDataTransferService {
    * @param {CMIDataForTransfer} cmiData - CMI data from runtime
    */
   public transferPrimaryObjective(activity: Activity, cmiData: CMIDataForTransfer): void {
+    // Transfer progress measure first so completedByMeasure completion derivation
+    // and measure rollup both see the latest value.
+    let hasProgressMeasure = false;
+    if (cmiData.progress_measure && cmiData.progress_measure !== "") {
+      const progressMeasure = parseFloat(cmiData.progress_measure);
+      if (!isNaN(progressMeasure)) {
+        hasProgressMeasure = true;
+        activity.progressMeasure = progressMeasure;
+        activity.progressMeasureStatus = true;
+        activity.attemptCompletionAmount = progressMeasure;
+        activity.attemptCompletionAmountStatus = true;
+
+        if (activity.primaryObjective) {
+          activity.primaryObjective.progressMeasure = progressMeasure;
+          activity.primaryObjective.progressMeasureStatus = true;
+        }
+      }
+    }
+
+    if (!hasProgressMeasure) {
+      activity.attemptCompletionAmountStatus = false;
+    }
+
     // Transfer completion status
-    const validatedCompletionStatus = validateCompletionStatus(cmiData.completion_status);
-    if (validatedCompletionStatus && validatedCompletionStatus !== CompletionStatus.UNKNOWN) {
-      activity.completionStatus = validatedCompletionStatus;
-      activity.attemptProgressStatus = true;
+    if (activity.completedByMeasure) {
+      const completionStatus = evaluateCompletionStatusFromThreshold({
+        completionThreshold: activity.minProgressMeasure,
+        progressMeasure: cmiData.progress_measure,
+        storedCompletionStatus: CompletionStatus.UNKNOWN,
+      });
+
+      activity.completionStatus = completionStatus as CompletionStatus;
+      activity.attemptProgressStatus = completionStatus !== CompletionStatus.UNKNOWN;
+    } else {
+      const validatedCompletionStatus = validateCompletionStatus(cmiData.completion_status);
+      if (validatedCompletionStatus && validatedCompletionStatus !== CompletionStatus.UNKNOWN) {
+        activity.completionStatus = validatedCompletionStatus;
+        activity.attemptProgressStatus = true;
+      }
     }
 
     // Collect values that need to be transferred
@@ -211,20 +246,6 @@ export class RteDataTransferService {
         activity.primaryObjective.progressStatus = true;
       }
     }
-
-    // Transfer progress measure
-    if (cmiData.progress_measure && cmiData.progress_measure !== "") {
-      const progressMeasure = parseFloat(cmiData.progress_measure);
-      if (!isNaN(progressMeasure)) {
-        activity.progressMeasure = progressMeasure;
-        activity.progressMeasureStatus = true;
-
-        if (activity.primaryObjective) {
-          activity.primaryObjective.progressMeasure = progressMeasure;
-          activity.primaryObjective.progressMeasureStatus = true;
-        }
-      }
-    }
   }
 
   /**
@@ -268,7 +289,10 @@ export class RteDataTransferService {
 
       // Transfer completion status
       const validatedObjCompletionStatus = validateCompletionStatus(cmiObjective.completion_status);
-      if (validatedObjCompletionStatus && validatedObjCompletionStatus !== CompletionStatus.UNKNOWN) {
+      if (
+        validatedObjCompletionStatus &&
+        validatedObjCompletionStatus !== CompletionStatus.UNKNOWN
+      ) {
         activityObjective.completionStatus = validatedObjCompletionStatus;
       }
 

--- a/src/cmi/scorm2004/sequencing/handlers/termination_handler.ts
+++ b/src/cmi/scorm2004/sequencing/handlers/termination_handler.ts
@@ -1,6 +1,10 @@
 import { Activity } from "../activity";
 import { ActivityTree } from "../activity_tree";
-import { SequencingProcess, SequencingRequestType, PostConditionResult } from "../sequencing_process";
+import {
+  SequencingProcess,
+  SequencingRequestType,
+  PostConditionResult,
+} from "../sequencing_process";
 import { RollupProcess } from "../rollup_process";
 import { RuleActionType } from "../sequencing_rules";
 import { SelectionRandomization } from "../selection_randomization";
@@ -61,7 +65,7 @@ export class TerminationHandler {
     rollupProcess: RollupProcess,
     globalObjectiveMap: Map<string, any>,
     eventCallback: ((eventType: string, data?: any) => void) | null = null,
-    options?: TerminationHandlerOptions
+    options?: TerminationHandlerOptions,
   ) {
     this.activityTree = activityTree;
     this.sequencingProcess = sequencingProcess;
@@ -99,7 +103,7 @@ export class TerminationHandler {
   public processTerminationRequest(
     request: SequencingRequestType,
     hasSequencingRequest: boolean = false,
-    exitType?: string
+    exitType?: string,
   ): TerminationResult {
     const currentActivity = this.activityTree.currentActivity;
 
@@ -114,8 +118,7 @@ export class TerminationHandler {
 
     // TB.2.3-2: Check if trying to terminate already-terminated activity
     if (
-      (request === SequencingRequestType.EXIT ||
-        request === SequencingRequestType.ABANDON) &&
+      (request === SequencingRequestType.EXIT || request === SequencingRequestType.ABANDON) &&
       !currentActivity.isActive
     ) {
       return {
@@ -186,15 +189,12 @@ export class TerminationHandler {
    */
   public handleExitTermination(
     currentActivity: Activity,
-    hasSequencingRequest: boolean
+    hasSequencingRequest: boolean,
   ): TerminationResult {
     return this.handleExit(currentActivity, hasSequencingRequest);
   }
 
-  private handleExit(
-    currentActivity: Activity,
-    hasSequencingRequest: boolean
-  ): TerminationResult {
+  private handleExit(currentActivity: Activity, hasSequencingRequest: boolean): TerminationResult {
     // TB.2.3 step 3.0: For cluster activities, terminate descendant attempts first
     if (currentActivity.children.length > 0) {
       this.terminateDescendants(currentActivity);
@@ -218,6 +218,23 @@ export class TerminationHandler {
       // Continue to post-condition evaluation on the new current activity (parent or original)
     }
 
+    // TB.2.1: Evaluate ancestor exit action rules from the root down to the
+    // parent of the terminating activity. A firing ancestor "exit" rule exits
+    // that cluster before TB.2.2 post-condition processing chooses the next
+    // sequencing request.
+    const ancestorExitResult = this.applyAncestorExitActionRules(currentActivity);
+    if (ancestorExitResult.action === "EXIT_ALL") {
+      return this.handleExitAll(ancestorExitResult.activity || currentActivity);
+    }
+    if (ancestorExitResult.exception) {
+      return {
+        terminationRequest: SequencingRequestType.EXIT,
+        sequencingRequest: null,
+        exception: ancestorExitResult.exception,
+        valid: false,
+      };
+    }
+
     // TB.2.3 step 3.3: POST-CONDITION LOOP
     let processedExit: boolean;
     let postConditionResult: PostConditionResult;
@@ -228,7 +245,7 @@ export class TerminationHandler {
 
       // TB.2.3 step 3.3.2: Apply Sequencing Post Condition Rules Subprocess
       postConditionResult = this.evaluatePostConditions(
-        this.activityTree.currentActivity || currentActivity
+        this.activityTree.currentActivity || currentActivity,
       );
 
       // TB.2.3 step 3.3.3: If returns EXIT_ALL, change termination type and break
@@ -273,12 +290,8 @@ export class TerminationHandler {
       // If processedExit is true, we need to continue loop to evaluate the new activity's post-conditions
       if (!processedExit) {
         const atRoot =
-          (this.activityTree.currentActivity || currentActivity) ===
-          this.activityTree.root;
-        if (
-          atRoot &&
-          postConditionResult.sequencingRequest !== SequencingRequestType.RETRY
-        ) {
+          (this.activityTree.currentActivity || currentActivity) === this.activityTree.root;
+        if (atRoot && postConditionResult.sequencingRequest !== SequencingRequestType.RETRY) {
           // Return EXIT sequencing request (ends session)
           return {
             terminationRequest: SequencingRequestType.EXIT,
@@ -340,7 +353,7 @@ export class TerminationHandler {
    */
   private handleAbandon(
     currentActivity: Activity,
-    hasSequencingRequest: boolean
+    hasSequencingRequest: boolean,
   ): TerminationResult {
     // TB.2.3 step 6.1: Set activity as not active (no attempt end)
     currentActivity.isActive = false;
@@ -540,7 +553,7 @@ export class TerminationHandler {
    */
   public evaluateExitRules(
     activity: Activity,
-    recursionDepth: number = 0
+    recursionDepth: number = 0,
   ): { action: string | null; recursionDepth: number } {
     // Increment recursion depth to detect infinite loops
     recursionDepth++;
@@ -554,18 +567,16 @@ export class TerminationHandler {
 
       // Check rule condition combination
       if (rule.conditionCombination === "all") {
-        conditionsMet = rule.conditions.every((condition) =>
-          condition.evaluate(activity)
-        );
+        conditionsMet = rule.conditions.every((condition) => condition.evaluate(activity));
       } else {
-        conditionsMet = rule.conditions.some((condition) =>
-          condition.evaluate(activity)
-        );
+        conditionsMet = rule.conditions.some((condition) => condition.evaluate(activity));
       }
 
       if (conditionsMet) {
         // Return the action to take with recursion tracking
-        if (rule.action === RuleActionType.EXIT_PARENT) {
+        if (rule.action === RuleActionType.EXIT) {
+          return { action: "EXIT", recursionDepth };
+        } else if (rule.action === RuleActionType.EXIT_PARENT) {
           return { action: "EXIT_PARENT", recursionDepth };
         } else if (rule.action === RuleActionType.EXIT_ALL) {
           return { action: "EXIT_ALL", recursionDepth };
@@ -608,6 +619,67 @@ export class TerminationHandler {
 
     // Then terminate all activities
     this.terminateAll(rootActivity);
+  }
+
+  /**
+   * Sequencing Exit Action Rules Subprocess (TB.2.1) ancestor walk
+   * @spec SN Book: TB.2.1 (Sequencing Exit Action Rules Subprocess)
+   * @param {Activity} terminatingActivity - The activity whose attempt just ended
+   * @return {{action: string | null, activity?: Activity, exception?: string}}
+   */
+  private applyAncestorExitActionRules(terminatingActivity: Activity): {
+    action: string | null;
+    activity?: Activity;
+    exception?: string;
+  } {
+    const activityPath: Activity[] = [];
+    let current: Activity | null = terminatingActivity.parent;
+
+    while (current) {
+      activityPath.unshift(current);
+      current = current.parent;
+    }
+
+    for (const activity of activityPath) {
+      const exitAction = this.exitActionRulesSubprocess(activity);
+
+      if (exitAction === "EXIT_ALL") {
+        this.fireEvent("onAncestorExitAction", {
+          activity: activity.id,
+          action: exitAction,
+        });
+        return { action: "EXIT_ALL", activity };
+      }
+
+      if (exitAction === "EXIT_PARENT") {
+        if (!activity.parent) {
+          return { action: "EXIT_PARENT", activity, exception: "TB.2.3-4" };
+        }
+
+        this.terminateDescendants(activity.parent);
+        this.activityTree.currentActivity = activity.parent;
+        this.endAttempt(activity.parent);
+        this.fireEvent("onAncestorExitAction", {
+          activity: activity.id,
+          action: exitAction,
+          currentActivity: activity.parent.id,
+        });
+        return { action: "EXIT_PARENT", activity: activity.parent };
+      }
+
+      if (exitAction === "EXIT") {
+        this.terminateDescendants(activity);
+        this.activityTree.currentActivity = activity;
+        this.endAttempt(activity);
+        this.fireEvent("onAncestorExitAction", {
+          activity: activity.id,
+          action: exitAction,
+        });
+        return { action: "EXIT", activity };
+      }
+    }
+
+    return { action: null };
   }
 
   /**
@@ -725,18 +797,16 @@ export class TerminationHandler {
 
       // Check rule condition combination
       if (rule.conditionCombination === "all") {
-        conditionsMet = rule.conditions.every((condition) =>
-          condition.evaluate(activity)
-        );
+        conditionsMet = rule.conditions.every((condition) => condition.evaluate(activity));
       } else {
-        conditionsMet = rule.conditions.some((condition) =>
-          condition.evaluate(activity)
-        );
+        conditionsMet = rule.conditions.some((condition) => condition.evaluate(activity));
       }
 
       if (conditionsMet) {
         // Return the action to take
-        if (rule.action === RuleActionType.EXIT_PARENT) {
+        if (rule.action === RuleActionType.EXIT) {
+          return "EXIT";
+        } else if (rule.action === RuleActionType.EXIT_PARENT) {
           return "EXIT_PARENT";
         } else if (rule.action === RuleActionType.EXIT_ALL) {
           return "EXIT_ALL";

--- a/src/configuration/activity_tree_builder.ts
+++ b/src/configuration/activity_tree_builder.ts
@@ -154,6 +154,23 @@ export class ActivityTreeBuilder {
       activity.applyRollupConsiderations(activitySettings.rollupConsiderations);
     }
 
+    if (activitySettings.completionThreshold) {
+      const threshold = activitySettings.completionThreshold;
+
+      if (threshold.completedByMeasure !== undefined) {
+        activity.completedByMeasure = threshold.completedByMeasure;
+      }
+      if (threshold.minProgressMeasure !== undefined) {
+        activity.minProgressMeasure = threshold.minProgressMeasure;
+        activity.completionThreshold = threshold.minProgressMeasure.toString();
+      } else if (threshold.completedByMeasure) {
+        activity.completionThreshold = activity.minProgressMeasure.toString();
+      }
+      if (threshold.progressWeight !== undefined) {
+        activity.progressWeight = threshold.progressWeight;
+      }
+    }
+
     if (activitySettings.hideLmsUi) {
       const mergedHide = this.sequencingConfigBuilder.mergeHideLmsUi(
         activity.hideLmsUi,

--- a/src/handlers/scorm2004/cmi_handler.ts
+++ b/src/handlers/scorm2004/cmi_handler.ts
@@ -8,6 +8,7 @@ import {
 } from "../../cmi/scorm2004/interactions";
 import { CMICommentsObject } from "../../cmi/scorm2004/comments";
 import { ADLDataObject } from "../../cmi/scorm2004/adl";
+import { evaluateCompletionStatusFromThreshold } from "../../cmi/scorm2004/completion_status_evaluation";
 import {
   CompletionStatus,
   CorrectResponses,
@@ -97,8 +98,7 @@ export class Scorm2004CMIHandler {
     const parts = CMIElement.split(".");
     const index = Number(parts[2]);
     const interaction = this.context.cmi.interactions.childArray[index] as
-      | CMIInteractionsObject
-      | undefined;
+      CMIInteractionsObject | undefined;
 
     if (this.context.isInitialized()) {
       if (typeof interaction === "undefined" || !interaction.type) {
@@ -167,34 +167,11 @@ export class Scorm2004CMIHandler {
    * @returns {string} The evaluated completion status
    */
   evaluateCompletionStatus(): string {
-    const threshold = this.context.cmi.completion_threshold;
-    const progressMeasure = this.context.cmi.progress_measure;
-    const storedStatus = this.context.cmi.completion_status;
-
-    // If completion_threshold is defined
-    if (threshold !== "" && threshold !== null && threshold !== undefined) {
-      const thresholdValue = parseFloat(String(threshold));
-
-      if (!isNaN(thresholdValue)) {
-        // Check if progress_measure is set
-        if (progressMeasure !== "" && progressMeasure !== null && progressMeasure !== undefined) {
-          const progressValue = parseFloat(String(progressMeasure));
-
-          if (!isNaN(progressValue)) {
-            // Evaluate based on threshold comparison
-            return progressValue >= thresholdValue
-              ? CompletionStatus.COMPLETED
-              : CompletionStatus.INCOMPLETE;
-          }
-        }
-
-        // completion_threshold is defined but progress_measure is not set
-        return CompletionStatus.UNKNOWN;
-      }
-    }
-
-    // No completion_threshold defined - return stored value
-    return storedStatus || CompletionStatus.UNKNOWN;
+    return evaluateCompletionStatusFromThreshold({
+      completionThreshold: this.context.cmi.completion_threshold,
+      progressMeasure: this.context.cmi.progress_measure,
+      storedCompletionStatus: this.context.cmi.completion_status,
+    });
   }
 
   /**

--- a/src/services/SequencingService.ts
+++ b/src/services/SequencingService.ts
@@ -17,6 +17,8 @@ import { CMI } from "../cmi/scorm2004/cmi";
 import { CMIObjectivesObject } from "../cmi/scorm2004/objectives";
 import { ADL } from "../cmi/scorm2004/adl";
 import { global_constants } from "../constants/api_constants";
+import { CompletionStatus } from "../constants/enums";
+import { evaluateCompletionStatusFromThreshold } from "../cmi/scorm2004/completion_status_evaluation";
 import { RuleCondition } from "../cmi/scorm2004/sequencing/sequencing_rules";
 import {
   AuxiliaryResource,
@@ -544,8 +546,35 @@ export class SequencingService {
    * Update activity properties from current CMI values
    */
   private updateActivityFromCMI(activity: Activity): void {
+    // Update progress measure
+    let hasProgressMeasure = false;
+    if (this.cmi.progress_measure !== "") {
+      const progressMeasure = parseFloat(this.cmi.progress_measure);
+      if (!isNaN(progressMeasure)) {
+        hasProgressMeasure = true;
+        activity.progressMeasure = progressMeasure;
+        activity.progressMeasureStatus = true;
+        activity.attemptCompletionAmount = progressMeasure;
+        activity.attemptCompletionAmountStatus = true;
+      }
+    }
+
+    if (!hasProgressMeasure) {
+      activity.attemptCompletionAmountStatus = false;
+    }
+
     // Update completion status
-    if (this.cmi.completion_status !== "unknown") {
+    if (activity.completedByMeasure) {
+      const completionStatus = evaluateCompletionStatusFromThreshold({
+        completionThreshold: activity.minProgressMeasure,
+        progressMeasure: this.cmi.progress_measure,
+        storedCompletionStatus: CompletionStatus.UNKNOWN,
+      });
+
+      activity.completionStatus = completionStatus as
+        "completed" | "incomplete" | "not attempted" | "unknown";
+      activity.attemptProgressStatus = completionStatus !== CompletionStatus.UNKNOWN;
+    } else if (this.cmi.completion_status !== "unknown") {
       activity.completionStatus = this.cmi.completion_status as
         "completed" | "incomplete" | "not attempted" | "unknown";
       // Mark that content has set completion status
@@ -561,15 +590,6 @@ export class SequencingService {
       // Mark that content has set objective satisfaction status
       if (activity.primaryObjective) {
         activity.primaryObjective.progressStatus = true;
-      }
-    }
-
-    // Update progress measure
-    if (this.cmi.progress_measure !== "") {
-      const progressMeasure = parseFloat(this.cmi.progress_measure);
-      if (!isNaN(progressMeasure)) {
-        activity.progressMeasure = progressMeasure;
-        activity.progressMeasureStatus = true;
       }
     }
 

--- a/src/types/sequencing_types.ts
+++ b/src/types/sequencing_types.ts
@@ -51,6 +51,12 @@ export type AdlRollupConsiderationsSettings = {
   measureSatisfactionIfActive?: boolean;
 };
 
+export type CompletionThresholdSettings = {
+  completedByMeasure?: boolean;
+  minProgressMeasure?: number;
+  progressWeight?: number;
+};
+
 export type ActivitySettings = {
   id: string;
   title: string;
@@ -75,6 +81,7 @@ export type ActivitySettings = {
   sequencingControls?: SequencingControlsSettings;
   rollupRules?: RollupRulesSettings;
   rollupConsiderations?: AdlRollupConsiderationsSettings;
+  completionThreshold?: CompletionThresholdSettings;
   selectionRandomizationState?: SelectionRandomizationStateSettings;
   hideLmsUi?: HideLmsUiItem[];
   sequencingCollectionRefs?: string | string[];

--- a/test/api/Scorm2004API.sequencing.spec.ts
+++ b/test/api/Scorm2004API.sequencing.spec.ts
@@ -342,6 +342,69 @@ describe("SCORM 2004 API Sequencing Configuration Tests", () => {
       expect(root.children[0].isCompleted).toBe(true);
     });
 
+    it("should configure per-activity completionThreshold settings", () => {
+      const sequencingSettings = {
+        activityTree: {
+          id: "root",
+          title: "Root",
+          children: [
+            {
+              id: "threshold-sco",
+              title: "Threshold SCO",
+              completionThreshold: {
+                completedByMeasure: true,
+                minProgressMeasure: 0.5,
+                progressWeight: 0.25,
+              },
+            },
+          ],
+        },
+      };
+
+      const apiInstance = api({ sequencing: sequencingSettings });
+      const activity = apiInstance._sequencing.activityTree.getActivity("threshold-sco");
+
+      expect(activity?.completedByMeasure).toBe(true);
+      expect(activity?.minProgressMeasure).toBe(0.5);
+      expect(activity?.completionThreshold).toBe("0.5");
+      expect(activity?.progressWeight).toBe(0.25);
+    });
+
+    it("should populate cmi.completion_threshold from the delivered activity before initialize", () => {
+      const apiInstance = api({
+        sequencing: {
+          activityTree: {
+            id: "root",
+            title: "Root",
+            sequencingControls: {
+              flow: true,
+            },
+            children: [
+              {
+                id: "threshold-sco",
+                title: "Threshold SCO",
+                completionThreshold: {
+                  completedByMeasure: true,
+                  minProgressMeasure: 0.5,
+                },
+              },
+            ],
+          },
+        },
+      });
+
+      expect(apiInstance.lmsInitialize("")).toBe("true");
+      expect(apiInstance.getSequencingState().currentActivity?.id).toBe("threshold-sco");
+
+      apiInstance.reset();
+      expect(apiInstance.cmi.completion_threshold).toBe("0.5");
+
+      expect(apiInstance.lmsInitialize("")).toBe("true");
+      expect(apiInstance.lmsGetValue("cmi.completion_threshold")).toBe("0.5");
+      expect(apiInstance.lmsSetValue("cmi.progress_measure", "0.5")).toBe("true");
+      expect(apiInstance.lmsGetValue("cmi.completion_status")).toBe("completed");
+    });
+
     it("should handle partial sequencing controls configuration", () => {
       const sequencingSettings = {
         sequencingControls: {

--- a/test/cmi/scorm2004/sequencing/sx02_completion_threshold_exit_rules.spec.ts
+++ b/test/cmi/scorm2004/sequencing/sx02_completion_threshold_exit_rules.spec.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+import Scorm2004API from "../../../../src/Scorm2004API";
+import { LogLevelEnum } from "../../../../src/constants/enums";
+
+const SX02_ACTIVITY_TREE = {
+  id: "SX-02",
+  title: "SX-02",
+  sequencingControls: {
+    choice: false,
+    flow: true,
+  },
+  children: [
+    {
+      id: "activity_1",
+      title: "Activity 1",
+    },
+    {
+      id: "activity_2",
+      title: "Activity 2",
+      sequencingControls: {
+        choice: false,
+        flow: true,
+      },
+      sequencingRules: {
+        exitConditionRules: [
+          {
+            action: "exit",
+            conditionCombination: "any",
+            conditions: [
+              {
+                condition: "satisfied",
+              },
+            ],
+          },
+        ],
+        postConditionRules: [
+          {
+            action: "previous",
+            conditionCombination: "any",
+            conditions: [
+              {
+                condition: "satisfied",
+              },
+            ],
+          },
+        ],
+      },
+      rollupRules: {
+        rules: [
+          {
+            action: "satisfied",
+            consideration: "all",
+            conditions: [
+              {
+                condition: "completed",
+              },
+            ],
+          },
+        ],
+      },
+      children: [
+        {
+          id: "activity_3",
+          title: "Activity 3",
+          completionThreshold: {
+            completedByMeasure: true,
+            minProgressMeasure: 0.5,
+          },
+        },
+        {
+          id: "activity_4",
+          title: "Activity 4",
+        },
+        {
+          id: "activity_5",
+          title: "Activity 5",
+          completionThreshold: {
+            completedByMeasure: true,
+            minProgressMeasure: 0.75,
+          },
+        },
+      ],
+    },
+    {
+      id: "activity_6",
+      title: "Activity 6",
+    },
+  ],
+};
+
+function createApi(): Scorm2004API {
+  return new Scorm2004API({
+    autocommit: false,
+    logLevel: LogLevelEnum.NONE,
+    sequencing: {
+      activityTree: SX02_ACTIVITY_TREE,
+    },
+  });
+}
+
+function prepareNextVisit(api: Scorm2004API): void {
+  api.reset();
+  expect(api.lmsInitialize("")).toBe("true");
+}
+
+function currentActivityId(api: Scorm2004API): string | null {
+  return api.getSequencingState().currentActivity?.id ?? null;
+}
+
+function activityById(api: Scorm2004API, id: string): any {
+  const findActivity = (activity: any): any => {
+    if (!activity) return null;
+    if (activity.id === id) return activity;
+    for (const child of activity.children ?? []) {
+      const result = findActivity(child);
+      if (result) return result;
+    }
+    return null;
+  };
+
+  return findActivity(api.getSequencingState().rootActivity);
+}
+
+function visitAndContinue(api: Scorm2004API, cmiUpdates: Array<[string, string]>): string | null {
+  expect(cmiUpdates.map(([element, value]) => api.lmsSetValue(element, value))).toEqual(
+    cmiUpdates.map(() => "true"),
+  );
+  expect(api.lmsSetValue("adl.nav.request", "_continue")).toBe("true");
+  expect(api.lmsFinish("")).toBe("true");
+  return currentActivityId(api);
+}
+
+describe("ADL CTS SX-02 completion threshold and exit rules", () => {
+  it("derives completedByMeasure completion and applies ancestor exit/post-condition sequencing", () => {
+    const api = createApi();
+
+    expect(api.lmsInitialize("")).toBe("true");
+    expect(currentActivityId(api)).toBe("activity_1");
+
+    expect(visitAndContinue(api, [["cmi.exit", "normal"]])).toBe("activity_3");
+
+    prepareNextVisit(api);
+    expect(currentActivityId(api)).toBe("activity_3");
+    expect(
+      visitAndContinue(api, [
+        ["cmi.completion_status", "incomplete"],
+        ["cmi.progress_measure", "0.5"],
+        ["cmi.exit", "normal"],
+      ]),
+    ).toBe("activity_4");
+    expect(activityById(api, "activity_3").completionStatus).toBe("completed");
+    expect(activityById(api, "activity_3").attemptCompletionAmountStatus).toBe(true);
+    expect(activityById(api, "activity_3").attemptCompletionAmount).toBe(0.5);
+
+    prepareNextVisit(api);
+    expect(currentActivityId(api)).toBe("activity_4");
+    expect(
+      visitAndContinue(api, [
+        ["cmi.success_status", "failed"],
+        ["cmi.exit", "normal"],
+      ]),
+    ).toBe("activity_5");
+
+    prepareNextVisit(api);
+    expect(currentActivityId(api)).toBe("activity_5");
+    expect(
+      visitAndContinue(api, [
+        ["cmi.progress_measure", "0.9"],
+        ["cmi.exit", "normal"],
+      ]),
+    ).toBe("activity_1");
+    expect(activityById(api, "activity_2").objectiveSatisfiedStatus).toBe(true);
+  });
+});

--- a/test/integration/SX02CompletionThresholdExitRules_SCORM20044thEdition.spec.ts
+++ b/test/integration/SX02CompletionThresholdExitRules_SCORM20044thEdition.spec.ts
@@ -1,0 +1,252 @@
+import { expect, test } from "@playwright/test";
+import { configureWrapper, waitForPageReady } from "./helpers/scorm-common-helpers";
+import { getWrapperConfigs } from "./helpers/scorm2004-helpers";
+
+/**
+ * ADL CTS SX-02 regression coverage for SCORM 2004 4th Edition sequencing.
+ *
+ * This scenario exercises completionThreshold completedByMeasure behavior, rollup
+ * into an intermediate cluster, and TB.2.1 ancestor exit action rule processing
+ * before post-condition sequencing request selection.
+ */
+
+const SX02_ACTIVITY_TREE = {
+  id: "SX-02",
+  title: "SX-02",
+  sequencingControls: {
+    choice: false,
+    flow: true,
+  },
+  children: [
+    {
+      id: "activity_1",
+      title: "Activity 1",
+    },
+    {
+      id: "activity_2",
+      title: "Activity 2",
+      sequencingControls: {
+        choice: false,
+        flow: true,
+      },
+      sequencingRules: {
+        exitConditionRules: [
+          {
+            action: "exit",
+            conditionCombination: "any",
+            conditions: [
+              {
+                condition: "satisfied",
+              },
+            ],
+          },
+        ],
+        postConditionRules: [
+          {
+            action: "previous",
+            conditionCombination: "any",
+            conditions: [
+              {
+                condition: "satisfied",
+              },
+            ],
+          },
+        ],
+      },
+      rollupRules: {
+        rules: [
+          {
+            action: "satisfied",
+            consideration: "all",
+            conditions: [
+              {
+                condition: "completed",
+              },
+            ],
+          },
+        ],
+      },
+      children: [
+        {
+          id: "activity_3",
+          title: "Activity 3",
+          completionThreshold: {
+            completedByMeasure: true,
+            minProgressMeasure: 0.5,
+          },
+        },
+        {
+          id: "activity_4",
+          title: "Activity 4",
+        },
+        {
+          id: "activity_5",
+          title: "Activity 5",
+          completionThreshold: {
+            completedByMeasure: true,
+            minProgressMeasure: 0.75,
+          },
+        },
+      ],
+    },
+    {
+      id: "activity_6",
+      title: "Activity 6",
+    },
+  ],
+};
+
+const wrappers = getWrapperConfigs();
+
+type ActivitySnapshot = {
+  completionStatus: string;
+  successStatus: string;
+  objectiveSatisfiedStatus: boolean | null;
+  attemptCompletionAmount: number;
+  attemptCompletionAmountStatus: boolean;
+  progressMeasure: number;
+  progressMeasureStatus: boolean;
+};
+
+type VisitResult = {
+  currentActivityId: string | null;
+  setResults: string[];
+  navSetResult: string;
+  terminateResult: string;
+  activity3: ActivitySnapshot | null;
+  activity2: ActivitySnapshot | null;
+};
+
+async function setupSX02(page: any, wrapperPath: string): Promise<void> {
+  await configureWrapper(page, {
+    sequencing: {
+      activityTree: SX02_ACTIVITY_TREE,
+    },
+  });
+
+  await page.goto(wrapperPath);
+  await waitForPageReady(page);
+
+  const initResult = await page.evaluate(() => {
+    const api = (window as any).API_1484_11;
+    return api.lmsInitialize("");
+  });
+
+  expect(initResult).toBe("true");
+  await expect.poll(() => currentActivityId(page)).toBe("activity_1");
+}
+
+async function prepareNextVisit(page: any): Promise<void> {
+  const initResult = await page.evaluate(() => {
+    const api = (window as any).API_1484_11;
+    api.reset();
+    return api.lmsInitialize("");
+  });
+
+  expect(initResult).toBe("true");
+}
+
+async function currentActivityId(page: any): Promise<string | null> {
+  return await page.evaluate(() => {
+    const api = (window as any).API_1484_11;
+    return api.getSequencingState().currentActivity?.id ?? null;
+  });
+}
+
+async function visitAndContinue(
+  page: any,
+  cmiUpdates: Array<[string, string]>,
+): Promise<VisitResult> {
+  return await page.evaluate((updates) => {
+    const api = (window as any).API_1484_11;
+    const setResults = updates.map(([element, value]) => api.lmsSetValue(element, value));
+    const navSetResult = api.lmsSetValue("adl.nav.request", "_continue");
+    const terminateResult = api.lmsFinish("");
+
+    const state = api.getSequencingState();
+    const findActivity = (activity: any, id: string): any => {
+      if (!activity) return null;
+      if (activity.id === id) return activity;
+      for (const child of activity.children ?? []) {
+        const result = findActivity(child, id);
+        if (result) return result;
+      }
+      return null;
+    };
+    const snapshot = (activity: any): ActivitySnapshot | null => {
+      if (!activity) return null;
+      return {
+        completionStatus: activity.completionStatus,
+        successStatus: activity.successStatus,
+        objectiveSatisfiedStatus: activity.objectiveSatisfiedStatus,
+        attemptCompletionAmount: activity.attemptCompletionAmount,
+        attemptCompletionAmountStatus: activity.attemptCompletionAmountStatus,
+        progressMeasure: activity.progressMeasure,
+        progressMeasureStatus: activity.progressMeasureStatus,
+      };
+    };
+
+    return {
+      currentActivityId: state.currentActivity?.id ?? null,
+      setResults,
+      navSetResult,
+      terminateResult,
+      activity3: snapshot(findActivity(state.rootActivity, "activity_3")),
+      activity2: snapshot(findActivity(state.rootActivity, "activity_2")),
+    };
+  }, cmiUpdates);
+}
+
+wrappers.forEach((wrapper) => {
+  test.describe(`ADL CTS SX-02 completion threshold and exit rules (${wrapper.name})`, () => {
+    test("derives completedByMeasure completion and applies ancestor exit/post-condition sequencing", async ({
+      page,
+    }) => {
+      await setupSX02(page, wrapper.path);
+
+      const firstVisit = await visitAndContinue(page, [["cmi.exit", "normal"]]);
+      expect(firstVisit.setResults).toEqual(["true"]);
+      expect(firstVisit.navSetResult).toBe("true");
+      expect(firstVisit.terminateResult).toBe("true");
+      expect(firstVisit.currentActivityId).toBe("activity_3");
+
+      await prepareNextVisit(page);
+      expect(await currentActivityId(page)).toBe("activity_3");
+
+      const activity3Visit = await visitAndContinue(page, [
+        ["cmi.completion_status", "incomplete"],
+        ["cmi.progress_measure", "0.5"],
+        ["cmi.exit", "normal"],
+      ]);
+      expect(activity3Visit.setResults).toEqual(["true", "true", "true"]);
+      expect(activity3Visit.terminateResult).toBe("true");
+      expect(activity3Visit.currentActivityId).toBe("activity_4");
+      expect(activity3Visit.activity3?.completionStatus).toBe("completed");
+      expect(activity3Visit.activity3?.attemptCompletionAmountStatus).toBe(true);
+      expect(activity3Visit.activity3?.attemptCompletionAmount).toBe(0.5);
+
+      await prepareNextVisit(page);
+      expect(await currentActivityId(page)).toBe("activity_4");
+
+      const activity4Visit = await visitAndContinue(page, [
+        ["cmi.success_status", "failed"],
+        ["cmi.exit", "normal"],
+      ]);
+      expect(activity4Visit.setResults).toEqual(["true", "true"]);
+      expect(activity4Visit.terminateResult).toBe("true");
+      expect(activity4Visit.currentActivityId).toBe("activity_5");
+
+      await prepareNextVisit(page);
+      expect(await currentActivityId(page)).toBe("activity_5");
+
+      const activity5Visit = await visitAndContinue(page, [
+        ["cmi.progress_measure", "0.9"],
+        ["cmi.exit", "normal"],
+      ]);
+      expect(activity5Visit.setResults).toEqual(["true", "true"]);
+      expect(activity5Visit.terminateResult).toBe("true");
+      expect(activity5Visit.activity2?.objectiveSatisfiedStatus).toBe(true);
+      expect(activity5Visit.currentActivityId).toBe("activity_1");
+    });
+  });
+});


### PR DESCRIPTION
Fixes the ADL CTS SX-02 scenario: a cluster with rollup rule (childActivitySet=all, completed -> satisfied), an exit-condition rule (satisfied -> exit), and a post-condition rule (satisfied -> previous) never routed the learner back to the first activity for the revisit — flow continued forward instead.

Four independent gaps, each necessary:

1. **Settings plumbing** — `ActivitySettings` now accepts `completionThreshold: { completedByMeasure, minProgressMeasure, progressWeight }` per activity node and `ActivityTreeBuilder` maps it onto the existing `Activity` fields.
2. **Centralized measure-derived completion (RTE 4.2.4.1a)** — new `completion_status_evaluation.ts` holds the threshold comparison (numeric, `>=`); it is applied on every path that writes activity completion from CMI: `SequencingService.updateActivityFromCMI` and `RteDataTransferService.transferPrimaryObjective` (the latter previously clobbered the corrected status back to the raw SCO-set value during endAttempt). Both paths also feed `attemptCompletionAmount(Status)` from `cmi.progress_measure` so measure rollup has data. With `completedByMeasure=true`, an SCO-set `cmi.completion_status` no longer overrides the measure-derived status.
3. **TB.2.1 Sequencing Exit Action Rules Subprocess** — during exit termination, ancestor exit-condition rules are now evaluated top-down from the root to the terminating activity's parent. A firing `exit` rule terminates that cluster's descendants, ends its attempt, and makes it current, so the existing TB.2.3 post-condition loop processes the cluster's own post-condition rules and the generated sequencing request overrides the navigation default. Previously only the terminating leaf's own rules were ever evaluated (`EXIT_PARENT` bubbling).
4. **Delivery-time `cmi.completion_threshold`** — populated from the delivered activity so SCOs can read RTE 4.2.9 and the terminate-time derivation actually engages; terminate-time completion/success comparisons switched from string to numeric as hygiene.

**Tests**: new SX-02 regression spec (`test/cmi/scorm2004/sequencing/sx02_completion_threshold_exit_rules.spec.ts`) drives the full five-visit walk and asserts the activity_1 revisit after activity_5, plus a Playwright variant; new assertions in `Scorm2004API.sequencing.spec.ts` for the settings plumbing and RTE wiring. Full suite: 190 files / 6803 tests green; lint and build:all pass.

Follow-up to #1631 (TB.2.3 current-activity promotion) and #1636 (reset start-time) — third member of the same CTS-found sequencing family.