### PR TITLE
Stop enforcing the 250-char SPM on SCORM 2004 interaction and objective descriptions

### DIFF
--- a/src/cmi/scorm2004/interactions.ts
+++ b/src/cmi/scorm2004/interactions.ts
@@ -440,11 +440,14 @@ export class CMIInteractionsObject extends BaseCMI {
         scorm2004_errors.DEPENDENCY_NOT_ESTABLISHED as number,
       );
     } else {
+      // Note: SCORM 2004 specifies an SPM of 250 chars for description (localized_string_type).
+      // We intentionally do NOT enforce this limit to maximize LMS compatibility (#1642).
+      // The {lang=...} prefix format is still validated.
       if (
         check2004ValidFormat(
           this._cmi_element + ".description",
           description,
-          scorm2004_regex.CMILangString250,
+          scorm2004_regex.CMILangString,
           true,
         )
       ) {

--- a/src/cmi/scorm2004/objectives.ts
+++ b/src/cmi/scorm2004/objectives.ts
@@ -270,11 +270,14 @@ export class CMIObjectivesObject extends BaseCMI {
         scorm2004_errors.DEPENDENCY_NOT_ESTABLISHED as number,
       );
     } else {
+      // Note: SCORM 2004 specifies an SPM of 250 chars for description (localized_string_type).
+      // We intentionally do NOT enforce this limit to maximize LMS compatibility (#1642).
+      // The {lang=...} prefix format is still validated.
       if (
         check2004ValidFormat(
           this._cmi_element + ".description",
           description,
-          scorm2004_regex.CMILangString250,
+          scorm2004_regex.CMILangString,
           true,
         )
       ) {

--- a/src/constants/regex.ts
+++ b/src/constants/regex.ts
@@ -179,6 +179,9 @@ export const scorm2004_regex = {
   /** CMILangString250 - String with optional language tag, max 250 chars (RTE C.1.3) */
   CMILangString250: "^({lang=([a-zA-Z]{1,8}|i|x)(-[a-zA-Z0-9-]{2,8})?})?((?!{.*$).{0,250}$)?$",
 
+  /** CMILangString - Optional language tag, no length cap; RTE C.1.3 SPM is a floor and is deliberately not enforced */
+  CMILangString: "^({lang=([a-zA-Z]{1,8}|i|x)(-[a-zA-Z0-9-]{2,8})?})?((?!{.*$).*$)?$",
+
   /** CMILangcr - Language tag pattern with content */
   CMILangcr: "^(({lang=([a-zA-Z]{1,8}|i|x)?(-[a-zA-Z0-9-]{2,8})?}))(.*?)$",
 

--- a/test/cmi/scorm2004_objectives.spec.ts
+++ b/test/cmi/scorm2004_objectives.spec.ts
@@ -316,15 +316,16 @@ describe("SCORM 2004 Objectives Tests", () => {
           expect(objectiveObj.description).toBe("Another description");
         });
 
-        it("should reject invalid description values", () => {
+        it("should accept long descriptions and reject malformed language tags", () => {
           const objectiveObj = new CMIObjectivesObject();
           objectiveObj.id = "objective-1"; // Set ID first to avoid dependency error
 
-          // Create a string that's too long (more than 250 characters)
-          const tooLongDescription = "a".repeat(251);
+          const longDescription = "a".repeat(251);
+          objectiveObj.description = longDescription;
+          expect(objectiveObj.description).toBe(longDescription);
 
           expect(() => {
-            objectiveObj.description = tooLongDescription;
+            objectiveObj.description = "{lang=123}Invalid description";
           }).toThrow();
         });
 

--- a/test/field_values.ts
+++ b/test/field_values.ts
@@ -187,6 +187,7 @@ export const scorm2004Values: Scorm2004Values = {
     "{lang=en-98} learner comment",
     "{lang=eng-98-9} learner comment",
     "{lang=eng-98-9fhgj}" + "x".repeat(250),
+    "{lang=eng-98-9fhgj}" + "x".repeat(251),
     "learner comment",
     "learner comment}",
     "{lang=i-xx}",
@@ -198,7 +199,6 @@ export const scorm2004Values: Scorm2004Values = {
     "{lang=i-x}",
     "{lang=eng-98-9fhgj}{ learner comment",
     "{learner comment",
-    "{lang=eng-98-9fhgj}" + "x".repeat(251),
     "{lang=eng-98-9fhgj}{" + "x".repeat(249),
   ],
   validNavRequest: [

--- a/test/validation/boundary-values.spec.ts
+++ b/test/validation/boundary-values.spec.ts
@@ -521,7 +521,7 @@ describe("Boundary Value Tests", () => {
     });
 
     describe("String length boundaries - description", () => {
-      // Spec Reference: SCORM 2004 RTE Section 4.2 - Long Identifier (250 chars)
+      // Spec Reference: SCORM 2004 RTE C.1.3 - The 250-character SPM is not enforced
 
       it("Should accept interaction description at exactly 250 characters", () => {
         api.lmsSetValue("cmi.interactions.0.id", "int-1");
@@ -531,9 +531,36 @@ describe("Boundary Value Tests", () => {
         expect(api.lmsGetLastError()).toBe("0");
       });
 
-      it("Should reject interaction description at 251 characters", () => {
+      it("Should accept interaction description at 251 characters", () => {
         api.lmsSetValue("cmi.interactions.0.id", "int-1");
         const description = "x".repeat(251);
+        const result = api.lmsSetValue("cmi.interactions.0.description", description);
+        expect(result).toBe("true");
+        expect(api.lmsGetLastError()).toBe("0");
+        expect(api.lmsGetValue("cmi.interactions.0.description")).toBe(description);
+      });
+
+      it("Should accept Articulate Rise interaction description at 253 characters (#1642)", () => {
+        api.lmsSetValue("cmi.interactions.0.id", "int-1");
+        const description = "x".repeat(253);
+        const result = api.lmsSetValue("cmi.interactions.0.description", description);
+        expect(result).toBe("true");
+        expect(api.lmsGetLastError()).toBe("0");
+        expect(api.lmsGetValue("cmi.interactions.0.description")).toBe(description);
+      });
+
+      it("Should accept interaction description with language prefix and body over 250 characters", () => {
+        api.lmsSetValue("cmi.interactions.0.id", "int-1");
+        const description = "{lang=en}" + "x".repeat(251);
+        const result = api.lmsSetValue("cmi.interactions.0.description", description);
+        expect(result).toBe("true");
+        expect(api.lmsGetLastError()).toBe("0");
+        expect(api.lmsGetValue("cmi.interactions.0.description")).toBe(description);
+      });
+
+      it("Should reject interaction description with malformed language prefix", () => {
+        api.lmsSetValue("cmi.interactions.0.id", "int-1");
+        const description = "{lang=123}" + "x".repeat(251);
         const result = api.lmsSetValue("cmi.interactions.0.description", description);
         expect(result).toBe("false");
         expect(api.lmsGetLastError()).toBe("406");


### PR DESCRIPTION
# Pull Request

## Description
SCORM 2004 `cmi.interactions.n.description` and `cmi.objectives.n.description` rejected values over 250 characters with error 406. The 250-character SPM in the RTE is a floor ("smallest permitted maximum"), not a ceiling, so an LMS that accepts more is still conformant. Articulate Rise regularly sends question stems longer than 250 characters, which made every long multiple-choice question log a 406 and drop the description entirely.

This change removes the length cap on those two fields while keeping the `{lang=...}` prefix validation. Malformed language tags still return 406.

## Related Issues
Fixes #1642

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Implementation Details
- Added an uncapped `CMILangString` regex next to `CMILangString250`. The shared `CMILangString250` constant is untouched because the fill-in `learner_response` format and sequencing `Activity.title` also use it and should keep their current behavior.
- Swapped the two description setters to the new regex, with a comment in the same style as the existing unenforced-SPM notes on `learner_id`, `learner_name`, and `launch_data`.
- The ADL CTS fixtures in `test/conformance/adl` contain no over-SPM rejection cases, so conformance coverage is unaffected.

## Testing Performed
- Boundary-value spec: descriptions at 251 and 253 characters (the #1642 case) are accepted and read back, a `{lang=en}` prefix with a body over 250 characters is accepted, and a malformed `{lang=123}` prefix still returns 406.
- Objectives spec updated the same way, keeping a malformed-language-tag rejection case.
- Moved a 251-character language-tagged value from the invalid to the valid list in `test/field_values.ts`, which feeds the generated interaction and objective cases.

```
Test Files  194 passed (194)
     Tests  6828 passed (6828)
```

`npm run lint:fix` reports no changes.