### PR TITLE
Bound the validation memoization cache

### DIFF
--- a/src/cmi/common/validation.ts
+++ b/src/cmi/common/validation.ts
@@ -42,6 +42,8 @@ export const checkValidFormat = memoize(
     const valueKey = typeof value === "string" ? value : `[${typeof value}]`;
     return `${CMIElement}:${valueKey}:${regexPattern}:${errorCode}:${allowEmptyString || false}`;
   },
+  // Normal capped CMI values and regexes fit within 2000 characters; large uncapped values bypass caching.
+  { maxEntries: 1000, maxKeyLength: 2000 },
 );
 
 /**
@@ -100,4 +102,5 @@ export const checkValidRange = memoize(
   // since it can't be stringified and doesn't affect the validation result
   (CMIElement, value, rangePattern, errorCode, _errorClass) =>
     `${CMIElement}:${value}:${rangePattern}:${errorCode}`,
+  { maxEntries: 1000 },
 );

--- a/src/utilities/core.ts
+++ b/src/utilities/core.ts
@@ -578,6 +578,8 @@ export function stringMatches(str: string | null | undefined, tester: string): b
  * @param {T} fn - The function to memoize
  * @param {Function} [keyFn] - Optional function to generate a custom cache key.
  *                           Useful for functions with complex arguments that can't be serialized.
+ * @param {Object} [options] - Optional cache bounds. `maxEntries` applies FIFO eviction,
+ *                             while keys longer than `maxKeyLength` bypass the cache.
  * @return {T} A memoized version of the input function with the same signature
  *
  * @example
@@ -606,16 +608,24 @@ export function stringMatches(str: string | null | undefined, tester: string): b
 export function memoize<T extends (...args: any[]) => any>(
   fn: T,
   keyFn?: (...args: Parameters<T>) => string,
+  options?: { maxEntries?: number; maxKeyLength?: number },
 ): T {
   const cache = new Map<string, ReturnType<T>>();
 
   return ((...args: Parameters<T>): ReturnType<T> => {
     const key = keyFn ? keyFn(...args) : JSON.stringify(args);
 
+    if (options?.maxKeyLength !== undefined && key.length > options.maxKeyLength) {
+      return fn(...args);
+    }
+
     return cache.has(key)
       ? (cache.get(key) as ReturnType<T>)
       : (() => {
           const result = fn(...args);
+          if (options?.maxEntries !== undefined && cache.size >= options.maxEntries) {
+            cache.delete(cache.keys().next().value as string);
+          }
           cache.set(key, result);
           return result;
         })();

--- a/test/utilities/memoize.spec.ts
+++ b/test/utilities/memoize.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+import { memoize } from "../../src/utilities";
+
+describe("memoize", () => {
+  it("caches repeated calls without options", () => {
+    const fn = vi.fn((value: string) => value.toUpperCase());
+    const memoized = memoize(fn);
+
+    expect(memoized("value")).toBe("VALUE");
+    expect(memoized("value")).toBe("VALUE");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("evicts the oldest entry when maxEntries is reached", () => {
+    const fn = vi.fn((value: string) => value);
+    const memoized = memoize(fn, undefined, { maxEntries: 2 });
+
+    memoized("A");
+    memoized("B");
+    memoized("C");
+    expect(fn).toHaveBeenCalledTimes(3);
+
+    memoized("A");
+    expect(fn).toHaveBeenCalledTimes(4);
+
+    memoized("C");
+    expect(fn).toHaveBeenCalledTimes(4);
+  });
+
+  it("bypasses oversized keys while caching small keys", () => {
+    const fn = vi.fn((value: string) => value);
+    const memoized = memoize(fn, undefined, { maxKeyLength: 10 });
+
+    memoized("this key is too long");
+    memoized("this key is too long");
+    expect(fn).toHaveBeenCalledTimes(2);
+
+    memoized("A");
+    memoized("A");
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not cache thrown errors", () => {
+    const fn = vi.fn(() => {
+      throw new Error("failure");
+    });
+    const memoized = memoize(fn);
+
+    expect(() => memoized()).toThrow("failure");
+    expect(() => memoized()).toThrow("failure");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses a custom key function with options", () => {
+    const fn = vi.fn((value: { id: string; label: string }) => value.label);
+    const memoized = memoize(fn, (value) => value.id, {
+      maxEntries: 2,
+      maxKeyLength: 5,
+    });
+
+    expect(memoized({ id: "A", label: "first" })).toBe("first");
+    expect(memoized({ id: "A", label: "second" })).toBe("first");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description
`checkValidFormat` memoizes on a cache key that embeds the full value string, and `memoize` backs it with a module-level `Map` that never evicts. Every unique `cmi.suspend_data` value (up to 64KB, re-set before nearly every commit) became a permanent cache entry for the life of the page, and because the cache is module-level it survives API re-instantiation in SPA players. A long kiosk session with autocommit could retain tens of megabytes of stale suspend_data strings. #1643 widened the exposure by uncapping the description fields.

Only successful validations were ever cached (throws happen before the cache write), so this was purely unbounded memory growth, never a correctness issue.

## Related Issues
Follow-up flagged during review of #1643.

## Type of Change
- [x] Performance improvement

## Implementation Details
- `memoize` gains an optional third parameter `{ maxEntries?, maxKeyLength? }`. Keys longer than `maxKeyLength` bypass the cache entirely (re-running a regex on a large string costs microseconds; storing it forever costs memory). When the cache is full, the oldest entry is evicted FIFO via Map insertion order. With no options passed, behavior is unchanged, so the public API stays backward compatible.
- `checkValidFormat` now uses `{ maxEntries: 1000, maxKeyLength: 2000 }` — normal capped CMI values plus the longest regex fit comfortably under 2000 characters, while suspend_data and the uncapped description fields skip the cache. `checkValidRange` gets `{ maxEntries: 1000 }`; its keys are tiny.

## Testing Performed
- New `test/utilities/memoize.spec.ts` covers: baseline caching without options, FIFO eviction at `maxEntries`, oversized-key bypass alongside normal caching, throws never being cached, and a custom key function combined with both bounds.

```
Test Files  195 passed (195)
     Tests  6830 passed (6830)
```

`npm run lint:fix` reports no changes.