### PR TITLE
chore(deps): bump postcss to 8.5.23 to clear audit advisory (GHSA-r28c-9q8g-f849)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7202,9 +7202,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -7647,9 +7647,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -7667,7 +7667,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
## Description

`npm audit fix` bumps the transitive `postcss` dependency (pulled in by `vite`) from 8.5.16 to 8.5.23, clearing the high-severity advisory GHSA-r28c-9q8g-f849 (path traversal in source-map auto-loading, affects `postcss <=8.5.17`). Lockfile only, no `package.json` change; `nanoid` moves 3.3.15 to 3.3.16 as a postcss dependency.

The `Build & Unit Tests` job runs `npm audit --level=moderate`, which began failing on every open PR (and would on `master`) once this advisory was published earlier today. This clears the gate repo-wide.

## Related Issues

None.

## Type of Change

- [x] Other (please describe): dependency security patch (lockfile only)

## Implementation Details

- Ran `npm audit fix`. Only `package-lock.json` changed.
- `postcss` 8.5.16 → 8.5.23; `nanoid` 3.3.15 → 3.3.16 (transitive, pulled by postcss).
- No `package.json`, source, or `dist/` changes.

## Testing Performed

`npm audit --level=moderate` now exits 0, and the full unit suite passes.

```
found 0 vulnerabilities

Test Files  195 passed (195)
     Tests  6833 passed (6833)
```

## Checklist

- [x] This PR does not include changes to files under `dist/`
- [x] I have run the tests and all pass
- [x] Lockfile-only change; no source or documentation changes needed
- [x] My changes generate no new warnings or errors
