### PR TITLE
chore: bump version to 3.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scorm-again",
-  "version": "3.1.6",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scorm-again",
-      "version": "3.1.6",
+      "version": "3.2.0",
       "license": "MIT",
       "devDependencies": {
         "@cyclonedx/cyclonedx-npm": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scorm-again",
-  "version": "3.1.6",
+  "version": "3.2.0",
   "description": "A modern SCORM JavaScript run-time library for SCORM 1.2 and SCORM 2004",
   "main": "dist/scorm-again.js",
   "types": "index.d.ts",


### PR DESCRIPTION
## Description

Bumps the package version from 3.1.6 to 3.2.0 ahead of the next release. Minor bump because 3.1.6 added a new configurable option (terminate-beacon `Content-Type`) and changed a default logging behavior.

The next GitHub Release will publish 3.2.0 to npm; the release workflow then auto-bumps the patch digit from there as usual.

## Changes since the last published version

- fix(http): make terminate beacon Content-Type configurable (#1645, #1646) — new opt-in setting
- fix(scorm2004): log uninitialized-GetValue 403 at WARN by default (#1626, #1647) — default log-level change
- deps/docs housekeeping (#1648, #1649, #1650, #1651)

## Type of Change

- [x] Other: version bump for release

## Testing Performed

None required — only `package.json` and `package-lock.json` version fields change. CI runs the full suite on this PR.

## Checklist

- [x] This PR does not include changes to files under `dist/`
- [x] My changes generate no new warnings or errors