### PR TITLE
chore: bump version to 3.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scorm-again",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scorm-again",
-      "version": "3.2.1",
+      "version": "3.3.0",
       "license": "MIT",
       "devDependencies": {
         "@cyclonedx/cyclonedx-npm": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scorm-again",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "description": "A modern SCORM JavaScript run-time library for SCORM 1.2 and SCORM 2004",
   "main": "dist/scorm-again.js",
   "types": "index.d.ts",


### PR DESCRIPTION
## Description

Bumps the package version from 3.2.1 to 3.3.0 for the SCORM 2004 sequencing release.

The next GitHub Release will publish 3.3.0 to npm. After a successful publish, the release workflow will automatically advance `master` to 3.3.1.

## Changes

- update the root version in `package.json`
- update the root package version fields in `package-lock.json`

## Testing

The full GitHub Actions build, unit, Chromium, and Firefox integration matrix runs on this PR. The underlying release changes passed that matrix in #1665.

## Release Safety

- no files under `dist/` are changed
- no release tag or npm publication occurs until this PR is merged
