### PR TITLE
ci: drop stale dist files and migrate off deprecated attest-sbom

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -460,6 +460,14 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      # download-artifact unpacks the fresh build *over* the dist/ that
+      # checkout just restored, so any bundle the build no longer emits (e.g.
+      # the removed AICC entry points) survives from the checkout and is never
+      # staged as a deletion. Clearing dist/ first makes the commit below
+      # reflect exactly what the build produced, nothing more.
+      - name: Clear stale dist before download
+        run: rm -rf dist
+
       - name: Download build artifacts
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,7 +193,7 @@ jobs:
       # Attest the SBOM against the same tarball, so consumers can
       # verify the SBOM corresponds to the exact npm artifact.
       - name: Attest SBOM
-        uses: actions/attest-sbom@v4
+        uses: actions/attest@v4.2.2
         with:
           subject-path: ${{ steps.pack.outputs.tarball }}
           sbom-path: 'sbom.cdx.json'


### PR DESCRIPTION
Two CI fixes, both surfaced by the 3.3.1 release run.

## Stale files in `dist/`

The `finalize` job checks out master, which restores the committed `dist/`, then `download-artifact` unpacks the fresh build on top of it. Anything the build no longer emits survives from the checkout, so git never sees a deletion and the file stays committed indefinitely.

`npm run clean` does wipe `dist/`, but it runs in `build-and-unit` — a different job with a different workspace, so it never affects what `finalize` commits.

The AICC bundles and type declarations have been riding along this way since AICC support was removed in 6c04507: 34 orphaned files that no entry point in `package.json` references. They do not reach npm, since the publish job packs a freshly built `dist/`, but anyone loading the library from a git tag through unpkg or jsDelivr still sees them.

Clearing `dist/` before the download makes the commit reflect exactly what the build produced. The next master build will stage the orphan deletions on its own.

## Deprecated `actions/attest-sbom`

The 3.3.1 release run warned that `actions/attest-sbom` is deprecated. It now runs as a wrapper over `actions/attest` and is slated for removal.

`actions/attest` accepts the same `sbom-path` input and works out the predicate type from the file, so `subject-path` and `sbom-path` carry over unchanged. Pinned to `v4.2.2` to match the `attest-build-provenance` step directly above it.

## Verification

- Both workflow files parse as valid YAML; job and step lists confirmed unchanged apart from the added step.
- `Clear stale dist before download` sits between `Install dependencies` and `Download build artifacts` in `finalize`, so the bundle analyzer and the commit step both see only fresh output.
- No `src/`, `test/`, or `dist/` changes, so `guard-dist` passes.

The attest change cannot be exercised until the next release, since `release.yml` only runs on `release: created`.