### PR TITLE
fix(scorm12): align RTE error codes and return values with the ADL CTS

### DIFF
--- a/src/BaseAPI.ts
+++ b/src/BaseAPI.ts
@@ -796,9 +796,12 @@ export default abstract class BaseAPI implements IBaseAPI {
     if (this.isNotInitialized()) {
       const errorCode = this._error_codes.TERMINATION_BEFORE_INIT ?? 0;
       this.throwSCORMError("api", errorCode);
-      // Per SCORM 2004 3rd Ed RTE 3.1.3.2: return "false" for error 112
-      // SCORM 1.2 ADL CTS sco03.htm requires "false" for error 301
-      if (errorCode === 112 || errorCode === 301) returnValue = global_constants.SCORM_FALSE;
+      // Terminating before initializing always fails, under every standard we
+      // implement: SCORM 2004 3rd Ed RTE 3.1.3.2 (error 112) and SCORM 1.2 per
+      // ADL CTS sco03.htm (error 301) both require "false". Unlike the branch
+      // below for a repeated termination, no error table treats this as a
+      // successful call, so the result does not depend on the code.
+      returnValue = global_constants.SCORM_FALSE;
     } else if (checkTerminated && this.isTerminated()) {
       const errorCode = this._error_codes.MULTIPLE_TERMINATION ?? 0;
       this.throwSCORMError("api", errorCode);
@@ -999,9 +1002,12 @@ export default abstract class BaseAPI implements IBaseAPI {
     if (this.isNotInitialized()) {
       const errorCode = this._error_codes.COMMIT_BEFORE_INIT ?? 0;
       this.throwSCORMError("api", errorCode);
-      // Per SCORM 2004 3rd Ed RTE 3.1.4.3: return "false" for error 142
-      // SCORM 1.2 ADL CTS sco03.htm requires "false" for error 301
-      if (errorCode === 142 || errorCode === 301) returnValue = global_constants.SCORM_FALSE;
+      // Committing before initializing always fails, under every standard we
+      // implement: SCORM 2004 3rd Ed RTE 3.1.4.3 (error 142) and SCORM 1.2 per
+      // ADL CTS sco03.htm (error 301) both require "false". Unlike the branch
+      // below for a commit after terminate, no error table treats this as a
+      // successful call, so the result does not depend on the code.
+      returnValue = global_constants.SCORM_FALSE;
     } else if (checkTerminated && this.isTerminated()) {
       const errorCode = this._error_codes.COMMIT_AFTER_TERM ?? 0;
       this.throwSCORMError("api", errorCode);

--- a/src/BaseAPI.ts
+++ b/src/BaseAPI.ts
@@ -797,8 +797,8 @@ export default abstract class BaseAPI implements IBaseAPI {
       const errorCode = this._error_codes.TERMINATION_BEFORE_INIT ?? 0;
       this.throwSCORMError("api", errorCode);
       // Per SCORM 2004 3rd Ed RTE 3.1.3.2: return "false" for error 112
-      // SCORM 1.2 (error 101) returns "true" for error conditions
-      if (errorCode === 112) returnValue = global_constants.SCORM_FALSE;
+      // SCORM 1.2 ADL CTS sco03.htm requires "false" for error 301
+      if (errorCode === 112 || errorCode === 301) returnValue = global_constants.SCORM_FALSE;
     } else if (checkTerminated && this.isTerminated()) {
       const errorCode = this._error_codes.MULTIPLE_TERMINATION ?? 0;
       this.throwSCORMError("api", errorCode);
@@ -1000,8 +1000,8 @@ export default abstract class BaseAPI implements IBaseAPI {
       const errorCode = this._error_codes.COMMIT_BEFORE_INIT ?? 0;
       this.throwSCORMError("api", errorCode);
       // Per SCORM 2004 3rd Ed RTE 3.1.4.3: return "false" for error 142
-      // SCORM 1.2 (error 301) returns "true" for error conditions
-      if (errorCode === 142) returnValue = global_constants.SCORM_FALSE;
+      // SCORM 1.2 ADL CTS sco03.htm requires "false" for error 301
+      if (errorCode === 142 || errorCode === 301) returnValue = global_constants.SCORM_FALSE;
     } else if (checkTerminated && this.isTerminated()) {
       const errorCode = this._error_codes.COMMIT_AFTER_TERM ?? 0;
       this.throwSCORMError("api", errorCode);

--- a/src/Scorm12API.ts
+++ b/src/Scorm12API.ts
@@ -157,7 +157,7 @@ class Scorm12API extends BaseAPI {
    * - Parameter must be empty string ("")
    * - Returns "true" on success, "false" on failure
    * - Commits all data to persistent storage
-   * - Sets error 101 if not initialized
+   * - Sets error 301 if not initialized
    * - Sets error 101 if already terminated
    * - Processes navigation events (continue/previous) if nav.event is set
    *
@@ -237,7 +237,7 @@ class Scorm12API extends BaseAPI {
    * - Parameter must be empty string ("")
    * - Requests persistence of all data set since last successful commit
    * - Returns "true" on success, "false" on failure
-   * - Sets error 101 if not initialized
+   * - Sets error 301 if not initialized
    * - Sets error 391 if commit failed
    * - Does not terminate the communication session
    *
@@ -249,6 +249,11 @@ class Scorm12API extends BaseAPI {
     if (parameter !== "") {
       this.throwSCORMError("api", this._error_codes.ARGUMENT_ERROR);
       return global_constants.SCORM_FALSE;
+    }
+
+    // Preserve the required false/301 state result even when commits are throttled.
+    if (this.isNotInitialized()) {
+      return this.commit("LMSCommit", false);
     }
 
     if (this.settings.throttleCommits) {

--- a/src/constants/error_codes.ts
+++ b/src/constants/error_codes.ts
@@ -35,6 +35,7 @@ export const global_errors: ErrorCode = {
 
 export const scorm12_errors: ErrorCode = {
   ...global_errors,
+  TERMINATION_BEFORE_INIT: 301,
   RETRIEVE_BEFORE_INIT: 301,
   STORE_BEFORE_INIT: 301,
   COMMIT_BEFORE_INIT: 301,

--- a/src/services/CMIValueAccessService.ts
+++ b/src/services/CMIValueAccessService.ts
@@ -225,6 +225,7 @@ export class CMIValueAccessService {
     const structure = CMIElement.split(".");
     let refObject: StringKeyMap = this.context.getDataModel();
     let attribute: string | null = null;
+    let foundFirstIndex = false;
 
     const uninitializedErrorMessage = `The data model element passed to ${methodName} (${CMIElement}) has not been initialized.`;
     const invalidErrorMessage = `The data model element passed to ${methodName} (${CMIElement}) is not a valid SCORM data model element.`;
@@ -271,6 +272,8 @@ export class CMIValueAccessService {
           structure,
           idx,
           CMIElement,
+          scorm2004,
+          foundFirstIndex,
           uninitializedErrorMessage,
         );
 
@@ -280,6 +283,7 @@ export class CMIValueAccessService {
 
         refObject = arrayResult.refObject;
         idx = arrayResult.idx;
+        foundFirstIndex = arrayResult.foundFirstIndex;
       }
     }
 
@@ -475,8 +479,7 @@ export class CMIValueAccessService {
         if (index > refObject.childArray.length) {
           const errorCode = scorm2004
             ? getErrorCode(this.context.errorCodes, "GENERAL_SET_FAILURE")
-            : getErrorCode(this.context.errorCodes, "INVALID_SET_VALUE") ||
-              getErrorCode(this.context.errorCodes, "GENERAL_SET_FAILURE");
+            : getErrorCode(this.context.errorCodes, "ARGUMENT_ERROR");
           this.context.throwSCORMError(
             CMIElement,
             errorCode,
@@ -588,29 +591,91 @@ export class CMIValueAccessService {
     structure: string[],
     idx: number,
     CMIElement: string,
+    scorm2004: boolean,
+    foundFirstIndex: boolean,
     uninitializedErrorMessage: string,
-  ): { refObject: StringKeyMap; idx: number; error: boolean } {
+  ): {
+    refObject: StringKeyMap;
+    idx: number;
+    foundFirstIndex: boolean;
+    error: boolean;
+  } {
     const index = parseInt(structure[idx + 1] || "", 10);
 
     if (!isNaN(index)) {
       const item = refObject.childArray[index];
 
-      if (item) {
+      // A readable record exists only when the requested index is within _count.
+      // Never construct a data-bearing child for an out-of-range read: constructor
+      // defaults would be indistinguishable from persisted learner data.
+      if (index < refObject.childArray.length && item) {
         return {
           refObject: item as unknown as StringKeyMap,
           idx: idx + 1,
+          foundFirstIndex: true,
           error: false,
         };
-      } else {
+      } else if (scorm2004) {
         this.context.throwSCORMError(
           CMIElement,
           getErrorCode(this.context.errorCodes, "VALUE_NOT_INITIALIZED"),
           uninitializedErrorMessage,
         );
-        return { refObject: refObject as unknown as StringKeyMap, idx, error: true };
+        return {
+          refObject: refObject as unknown as StringKeyMap,
+          idx,
+          foundFirstIndex,
+          error: true,
+        };
+      } else {
+        const collectionPath = structure.slice(0, idx + 1).join(".");
+        const interactionSubcollectionCount =
+          collectionPath === "cmi.interactions" &&
+          index === refObject.childArray.length &&
+          /^cmi\.interactions\.\d+\.(objectives|correct_responses)\._count$/.test(CMIElement);
+
+        if (interactionSubcollectionCount) {
+          // ADL sco07.htm expects an implemented interaction subcollection count
+          // to read as zero even when the interaction record does not yet exist.
+          const child = this.context.getChildElement(CMIElement, "", foundFirstIndex);
+          if (child) {
+            if (refObject.initialized) child.initialize();
+            return {
+              refObject: child as unknown as StringKeyMap,
+              idx: idx + 1,
+              foundFirstIndex: true,
+              error: false,
+            };
+          }
+        }
+
+        const interactionCollection =
+          collectionPath === "cmi.interactions" ||
+          /^cmi\.interactions\.\d+\.(objectives|correct_responses)$/.test(collectionPath);
+        // Interaction records and their nested entries are write-only (404).
+        // Readable objective records use 201, the collection argument error also
+        // used by ADL for an out-of-range SetValue.
+        this.context.throwSCORMError(
+          CMIElement,
+          getErrorCode(
+            this.context.errorCodes,
+            interactionCollection ? "WRITE_ONLY_ELEMENT" : "ARGUMENT_ERROR",
+          ),
+        );
+        return {
+          refObject: refObject as unknown as StringKeyMap,
+          idx,
+          foundFirstIndex,
+          error: true,
+        };
       }
     }
 
-    return { refObject: refObject as unknown as StringKeyMap, idx, error: false };
+    return {
+      refObject: refObject as unknown as StringKeyMap,
+      idx,
+      foundFirstIndex,
+      error: false,
+    };
   }
 }

--- a/src/services/ValidationService.ts
+++ b/src/services/ValidationService.ts
@@ -67,6 +67,10 @@ export class ValidationService {
    * @return {boolean} - True if validation passes, throws an error otherwise
    */
   validateScorm12Language(CMIElement: string, value: string): boolean {
+    // ADL SCORM 1.2 CTS sco08.htm checkAllPossibleCMIString255 treats blank as valid.
+    if (value === "") {
+      return true;
+    }
     return check12ValidFormat(CMIElement, value, scorm12_regex.CMIString256);
   }
 

--- a/test/api/ErrorConditions.spec.ts
+++ b/test/api/ErrorConditions.spec.ts
@@ -367,11 +367,11 @@ describe("Error Conditions Tests", () => {
         expect(api.lmsGetLastError()).toEqual(String(scorm12_errors.INITIALIZED));
       });
 
-      it("should set TERMINATION_BEFORE_INIT (101) error when attempting to terminate before initializing", () => {
+      it("should set TERMINATION_BEFORE_INIT (301) error when attempting to terminate before initializing", () => {
         const api = scorm12Api();
 
-        // Attempt to terminate without initializing
-        expect(api.lmsFinish()).toEqual("true");
+        // ADL SCORM 1.2 CTS LMSTestCourse01 sco03.htm lines 319-360.
+        expect(api.lmsFinish()).toEqual("false");
         expect(api.lmsGetLastError()).toEqual(String(scorm12_errors.TERMINATION_BEFORE_INIT));
       });
 
@@ -409,8 +409,8 @@ describe("Error Conditions Tests", () => {
       it("should set COMMIT_BEFORE_INIT (301) error when attempting to commit before initializing", () => {
         const api = scorm12Api();
 
-        // Attempt to commit without initializing
-        expect(api.lmsCommit()).toEqual("true");
+        // ADL SCORM 1.2 CTS LMSTestCourse01 sco03.htm lines 262-315.
+        expect(api.lmsCommit()).toEqual("false");
         expect(api.lmsGetLastError()).toEqual(String(scorm12_errors.COMMIT_BEFORE_INIT));
       });
     });

--- a/test/api/Scorm12API.additional.spec.ts
+++ b/test/api/Scorm12API.additional.spec.ts
@@ -408,6 +408,7 @@ describe("SCORM 1.2 API Additional Tests", () => {
       // throttleCommits requires useAsynchronousCommits
       const scorm12API = api({ throttleCommits: true, useAsynchronousCommits: true });
       const scheduleCommitSpy = vi.spyOn(scorm12API, "scheduleCommit");
+      scorm12API.lmsInitialize();
 
       const result = scorm12API.lmsCommit();
 

--- a/test/api/state-machine.spec.ts
+++ b/test/api/state-machine.spec.ts
@@ -79,14 +79,16 @@ describe("State Machine Tests", () => {
 
       it("LMSCommit should fail with error 301 before initialization", () => {
         const result = api.lmsCommit();
-        expect(result).toBe("true");
+        // ADL SCORM 1.2 CTS LMSTestCourse01 sco03.htm lines 262-315.
+        expect(result).toBe("false");
         expect(api.lmsGetLastError()).toBe("301");
       });
 
-      it("LMSFinish should fail with error 101 before initialization", () => {
+      it("LMSFinish should fail with error 301 before initialization", () => {
         const result = api.lmsFinish();
-        expect(result).toBe("true");
-        expect(api.lmsGetLastError()).toBe("101"); // TERMINATION_BEFORE_INIT
+        // ADL SCORM 1.2 CTS LMSTestCourse01 sco03.htm lines 319-360.
+        expect(result).toBe("false");
+        expect(api.lmsGetLastError()).toBe("301");
       });
     });
 

--- a/test/cmi/common/array_sequential_index.spec.ts
+++ b/test/cmi/common/array_sequential_index.spec.ts
@@ -5,6 +5,8 @@ import { scorm12_errors, scorm2004_errors } from "../../../src/constants/error_c
 
 describe("CMIArray Sequential Index Validation", () => {
   describe("SCORM 1.2 Array Index Validation", () => {
+    // ADL SCORM 1.2 CTS LMSTestCourse01 sco 02.htm lines 609-660 and
+    // sco08.htm lines 1826-1855 require 201 for non-sequential array indices.
     let scorm12API: Scorm12API;
 
     beforeEach(() => {
@@ -30,8 +32,7 @@ describe("CMIArray Sequential Index Validation", () => {
       const result = scorm12API.lmsSetValue("cmi.objectives.2.id", "obj_2");
       expect(result).toBe("false");
       const errorCode = scorm12API.lmsGetLastError();
-      // Should be INVALID_SET_VALUE (402) or GENERAL_SET_FAILURE
-      expect(errorCode).toBe(String(scorm12_errors.INVALID_SET_VALUE));
+      expect(errorCode).toBe(String(scorm12_errors.ARGUMENT_ERROR));
     });
 
     it("should allow updating existing index 0 in objectives array", () => {
@@ -61,14 +62,14 @@ describe("CMIArray Sequential Index Validation", () => {
       const result = scorm12API.lmsSetValue("cmi.interactions.2.id", "int_2");
       expect(result).toBe("false");
       const errorCode = scorm12API.lmsGetLastError();
-      expect(errorCode).toBe(String(scorm12_errors.INVALID_SET_VALUE));
+      expect(errorCode).toBe(String(scorm12_errors.ARGUMENT_ERROR));
     });
 
     it("should fail when setting index 5 on empty interactions array", () => {
       const result = scorm12API.lmsSetValue("cmi.interactions.5.id", "int_5");
       expect(result).toBe("false");
       const errorCode = scorm12API.lmsGetLastError();
-      expect(errorCode).toBe(String(scorm12_errors.INVALID_SET_VALUE));
+      expect(errorCode).toBe(String(scorm12_errors.ARGUMENT_ERROR));
     });
 
     it("should allow sequential setting in nested interactions.objectives array", () => {
@@ -84,7 +85,7 @@ describe("CMIArray Sequential Index Validation", () => {
       const result = scorm12API.lmsSetValue("cmi.interactions.0.objectives.2.id", "obj_2");
       expect(result).toBe("false");
       const errorCode = scorm12API.lmsGetLastError();
-      expect(errorCode).toBe(String(scorm12_errors.INVALID_SET_VALUE));
+      expect(errorCode).toBe(String(scorm12_errors.ARGUMENT_ERROR));
     });
 
     it("should allow sequential setting in interactions.correct_responses array", () => {
@@ -106,7 +107,7 @@ describe("CMIArray Sequential Index Validation", () => {
       const result = scorm12API.lmsSetValue("cmi.interactions.0.correct_responses.3.pattern", "d");
       expect(result).toBe("false");
       const errorCode = scorm12API.lmsGetLastError();
-      expect(errorCode).toBe(String(scorm12_errors.INVALID_SET_VALUE));
+      expect(errorCode).toBe(String(scorm12_errors.ARGUMENT_ERROR));
     });
   });
 
@@ -240,6 +241,7 @@ describe("CMIArray Sequential Index Validation", () => {
   });
 
   describe("Edge Cases", () => {
+    // ADL SCORM 1.2 CTS LMSTestCourse01 sco 02.htm lines 609-660 requires 201.
     let scorm12API: Scorm12API;
 
     beforeEach(() => {
@@ -252,7 +254,7 @@ describe("CMIArray Sequential Index Validation", () => {
       const result = scorm12API.lmsSetValue("cmi.objectives.100.id", "obj_100");
       expect(result).toBe("false");
       const errorCode = scorm12API.lmsGetLastError();
-      expect(errorCode).toBe(String(scorm12_errors.INVALID_SET_VALUE));
+      expect(errorCode).toBe(String(scorm12_errors.ARGUMENT_ERROR));
     });
 
     it("should allow filling gaps by adding sequential indices", () => {

--- a/test/conformance/adl/fixtures/scorm12-divergence-probes.json
+++ b/test/conformance/adl/fixtures/scorm12-divergence-probes.json
@@ -1,7 +1,7 @@
 {
   "id": "SCORM12-divergence-probes",
   "scormVersion": "1.2",
-  "source": "Hand-authored SCORM 1.2 RTE probes, expectations cross-checked against the decompiled ADL 1.2 CTS validators (org.adl.datamodels: CMICore, CMIScore, DataModelValidator, CMICategory). Each step asserts the ADL/spec-faithful return + GetLastError; confirmed scorm-again divergences are pinned via knownDivergence so the suite stays green and a future fix surfaces here. See SCORM12_COVERAGE.md (probes P1-P6).",
+  "source": "Hand-authored SCORM 1.2 RTE probes, expectations cross-checked against the decompiled ADL 1.2 CTS validators (org.adl.datamodels: CMICore, CMIScore, DataModelValidator, CMICategory) and authentic LMSTestCourse01 sources: sco03.htm lines 262-360 (pre-init Commit/Finish false+301), sco07.htm lines 714-901 (array child reads), sco08.htm lines 197-247 (blank CMIString255), sco 02.htm lines 609-660 and sco08.htm lines 1826-1855 (non-sequential arrays). Each step asserts the ADL/spec-faithful return + GetLastError; confirmed scorm-again divergences are pinned via knownDivergence so the suite stays green and a future fix surfaces here. See SCORM12_COVERAGE.md (probes P1-P6).",
   "activities": [
     {
       "id": "P1-score-range",
@@ -35,10 +35,13 @@
       "steps": [
         { "method": "Initialize", "expectedReturn": "true", "expectedErrorCode": "0" },
         {
-          "method": "GetValue", "element": "cmi.core.bogus",
-          "expectedReturn": "", "expectedErrorCode": "201",
+          "method": "GetValue",
+          "element": "cmi.core.bogus",
+          "expectedReturn": "",
+          "expectedErrorCode": "201",
           "knownDivergence": {
-            "actualReturn": "", "actualErrorCode": "401",
+            "actualReturn": "",
+            "actualErrorCode": "401",
             "finding": "After the P4 fix, GetValue of an unrecognized leaf returns 401 (not implemented) instead of the old 101 (general exception). ADL CTS uses 201 (invalid argument) for an invalid leaf in a valid category; 401 is the SCORM 1.2 'Not implemented error' and is spec-defensible. scorm-again deliberately maps all unknown elements uniformly to 401 rather than adopting ADL's 201/401 leaf-vs-category split.",
             "reference": "ADL CMICategory.determineElementValue NoSuchField -> 201"
           }
@@ -58,10 +61,14 @@
       "steps": [
         { "method": "Initialize", "expectedReturn": "true", "expectedErrorCode": "0" },
         {
-          "method": "SetValue", "element": "cmi.objectives.0.id", "value": "obj 1",
-          "expectedReturn": "false", "expectedErrorCode": "405",
+          "method": "SetValue",
+          "element": "cmi.objectives.0.id",
+          "value": "obj 1",
+          "expectedReturn": "false",
+          "expectedErrorCode": "405",
           "knownDivergence": {
-            "actualReturn": "true", "actualErrorCode": "0",
+            "actualReturn": "true",
+            "actualErrorCode": "0",
             "finding": "DELIBERATE divergence, not a defect: an objective id containing a space is accepted. ADL checkIdentifier rejects spaces (CMIIdentifier prohibits whitespace) -> 405, but scorm-again intentionally tolerates non-compliant identifiers to support real-world content that ships malformed ids. Do NOT change this to 405 without a product decision.",
             "reference": "ADL DataModelValidator.checkIdentifier (indexOf(' ') == -1); scorm-again deliberate leniency for non-compliant content"
           }
@@ -75,6 +82,64 @@
         { "method": "GetValue", "element": "cmi.core.exit", "expectedReturn": "", "expectedErrorCode": "404" },
         { "method": "GetValue", "element": "cmi.core.session_time", "expectedReturn": "", "expectedErrorCode": "404" },
         { "method": "SetValue", "element": "cmi.core.student_id", "value": "x", "expectedReturn": "false", "expectedErrorCode": "403" }
+      ]
+    },
+    {
+      "id": "F1-commit-before-initialize",
+      "steps": [
+        { "method": "Commit", "value": "", "expectedReturn": "false", "expectedErrorCode": "301" }
+      ]
+    },
+    {
+      "id": "F2-finish-before-initialize",
+      "steps": [
+        { "method": "Terminate", "value": "", "expectedReturn": "false", "expectedErrorCode": "301" }
+      ]
+    },
+    {
+      "id": "F3-unset-array-child-reads",
+      "steps": [
+        { "method": "Initialize", "expectedReturn": "true", "expectedErrorCode": "0" },
+        { "method": "GetValue", "element": "cmi.objectives._count", "expectedReturn": "0", "expectedErrorCode": "0" },
+        { "method": "GetValue", "element": "cmi.objectives.0.id", "expectedReturn": "", "expectedErrorCode": "201" },
+        { "method": "GetValue", "element": "cmi.objectives.0.status", "expectedReturn": "", "expectedErrorCode": "201" },
+        { "method": "GetValue", "element": "cmi.objectives.0.score.max", "expectedReturn": "", "expectedErrorCode": "201" },
+        { "method": "GetValue", "element": "cmi.objectives.9.score.max", "expectedReturn": "", "expectedErrorCode": "201" },
+        { "method": "GetValue", "element": "cmi.objectives._count", "expectedReturn": "0", "expectedErrorCode": "0" },
+        { "method": "GetValue", "element": "cmi.interactions._count", "expectedReturn": "0", "expectedErrorCode": "0" },
+        { "method": "GetValue", "element": "cmi.interactions.0.id", "expectedReturn": "", "expectedErrorCode": "404" },
+        { "method": "GetValue", "element": "cmi.interactions.9.id", "expectedReturn": "", "expectedErrorCode": "404" },
+        { "method": "GetValue", "element": "cmi.interactions.9.objectives._count", "expectedReturn": "", "expectedErrorCode": "404" },
+        { "method": "GetValue", "element": "cmi.interactions.9.correct_responses._count", "expectedReturn": "", "expectedErrorCode": "404" },
+        { "method": "GetValue", "element": "cmi.interactions.0.objectives._count", "expectedReturn": "0", "expectedErrorCode": "0" },
+        { "method": "GetValue", "element": "cmi.interactions.0.objectives.0.id", "expectedReturn": "", "expectedErrorCode": "404" },
+        { "method": "GetValue", "element": "cmi.interactions.0.correct_responses._count", "expectedReturn": "0", "expectedErrorCode": "0" },
+        { "method": "GetValue", "element": "cmi.interactions.0.correct_responses.0.pattern", "expectedReturn": "", "expectedErrorCode": "404" },
+        { "method": "GetValue", "element": "cmi.interactions._count", "expectedReturn": "0", "expectedErrorCode": "0" },
+        { "method": "SetValue", "element": "cmi.interactions.0.id", "value": "I00", "expectedReturn": "true", "expectedErrorCode": "0" },
+        { "method": "GetValue", "element": "cmi.interactions.0.objectives.0.id", "expectedReturn": "", "expectedErrorCode": "404" },
+        { "method": "GetValue", "element": "cmi.interactions.0.objectives.9.id", "expectedReturn": "", "expectedErrorCode": "404" },
+        { "method": "GetValue", "element": "cmi.interactions.0.correct_responses.0.pattern", "expectedReturn": "", "expectedErrorCode": "404" },
+        { "method": "GetValue", "element": "cmi.interactions.0.correct_responses.9.pattern", "expectedReturn": "", "expectedErrorCode": "404" }
+      ]
+    },
+    {
+      "id": "F4-blank-student-preference-language",
+      "steps": [
+        { "method": "Initialize", "expectedReturn": "true", "expectedErrorCode": "0" },
+        { "method": "SetValue", "element": "cmi.student_preference.language", "value": "", "expectedReturn": "true", "expectedErrorCode": "0" },
+        { "method": "GetValue", "element": "cmi.student_preference.language", "expectedReturn": "", "expectedErrorCode": "0" }
+      ]
+    },
+    {
+      "id": "F5-non-sequential-array-index",
+      "steps": [
+        { "method": "Initialize", "expectedReturn": "true", "expectedErrorCode": "0" },
+        { "method": "SetValue", "element": "cmi.objectives.0.id", "value": "O00", "expectedReturn": "true", "expectedErrorCode": "0" },
+        { "method": "SetValue", "element": "cmi.objectives.9.id", "value": "O09", "expectedReturn": "false", "expectedErrorCode": "201" },
+        { "method": "SetValue", "element": "cmi.interactions.0.id", "value": "I00", "expectedReturn": "true", "expectedErrorCode": "0" },
+        { "method": "SetValue", "element": "cmi.interactions.5.student_response", "value": "not sequential", "expectedReturn": "false", "expectedErrorCode": "201" },
+        { "method": "SetValue", "element": "cmi.interactions.0.correct_responses.5.pattern", "value": "not sequential", "expectedReturn": "false", "expectedErrorCode": "201" }
       ]
     }
   ]

--- a/test/property/validation-service.property.spec.ts
+++ b/test/property/validation-service.property.spec.ts
@@ -158,11 +158,9 @@ describe("ValidationService Property-based Tests", () => {
       );
     });
 
-    // Test that empty strings are rejected
-    it("should reject empty strings", () => {
-      expect(() => {
-        validationService.validateScorm12Language("api", "");
-      }).toThrow();
+    // ADL SCORM 1.2 CTS LMSTestCourse01 sco08.htm lines 197-209 accepts blank CMIString255.
+    it("should accept empty strings", () => {
+      expect(validationService.validateScorm12Language("api", "")).toBe(true);
     });
 
     // Test that any string longer than 256 characters fails validation

--- a/test/validation/boundary-values.spec.ts
+++ b/test/validation/boundary-values.spec.ts
@@ -262,12 +262,12 @@ describe("Boundary Value Tests", () => {
         expect(api.lmsSetValue("cmi.objectives.2.id", "obj-2")).toBe("true");
       });
 
-      // Note: SCORM 1.2 returns 402 (invalid set value) for skipped indexes
-      it("Should reject skipped array indexes with error 402", () => {
+      // ADL SCORM 1.2 CTS LMSTestCourse01 sco 02.htm lines 609-660 requires 201.
+      it("Should reject skipped array indexes with error 201", () => {
         api.lmsSetValue("cmi.objectives.0.id", "obj-0");
         const result = api.lmsSetValue("cmi.objectives.2.id", "obj-2");
         expect(result).toBe("false");
-        expect(api.lmsGetLastError()).toBe("402");
+        expect(api.lmsGetLastError()).toBe("201");
       });
 
       it("Should handle high array indexes sequentially", () => {


### PR DESCRIPTION
## What

Five SCORM 1.2 run-time environment divergences, found by driving ADL's real SCORM 1.2 CTS courses (`LMSTestCourse01`/`02`) through a live LMS rather than by re-reading the spec. Each fix cites the ADL test source that requires it.

| # | Behavior | Was | Now | ADL source |
|---|---|---|---|---|
| 1 | `LMSCommit`/`LMSFinish` before initialize | `"true"` | `"false"` | `sco03.htm` 262–360 |
| 2 | `TERMINATION_BEFORE_INIT` | `101` (inherited) | `301` | `sco03.htm` 319–360 |
| 3 | Read of a non-existent array child | `301` | `404` interactions / `201` objectives | `sco07.htm` 714–901 |
| 4 | Blank `cmi.student_preference.language` | `405` | accepted | `sco08.htm` 197–247 |
| 5 | Non-sequential array index | `402` | `201` | `sco 02.htm` 609–660, `sco08.htm` 1826–1855 |

**SCORM 2004 is untouched.** Its branches keep their own codes, and all 37 ADL-derived 2004 fixtures stay green.

## Notes on the trickier ones

**Fix 1** also needed a guard in `Scorm12API.lmsCommit()`. With `throttleCommits` enabled it short-circuits to `SCORM_TRUE` and schedules a deferred commit, so fixing `BaseAPI.commit()` alone left the throttled path still returning `"true"` for a session that never initialized.

**Fix 3** is the substantial one. The old `301` claims the session is not initialized, but the trace disproves that — `cmi.interactions._count` succeeds immediately before:

```
LMSGetValue(cmi.interactions._count) -> "0"  err=0     session IS initialized
LMSGetValue(cmi.interactions.0.id)   -> ""   err=301   should be 404 (write-only)
```

Interactions are write-only, so their leaf getters throw `404` once the child resolves. Objectives are readable, so resolving a child there would return constructor defaults — `cmi.objectives.0.score.max` would answer `"100"` with `err=0`, indistinguishable from persisted learner data. Out-of-range objective reads therefore return `201` and construct nothing. The bounds check is explicit rather than relying on which leaf getters happen to throw.

One carve-out: ADL expects an interaction's `objectives._count` and `correct_responses._count` to read as `"0"` before the interaction record exists, so that case still resolves.

## Tests

Six test files asserted the pre-fix behavior and are corrected against the ADL sources. Two of them named the correct error code in the title and asserted the wrong one in the body:

```ts
it("should set TERMINATION_BEFORE_INIT (101) error when attempting to terminate before initializing", () => {
  expect(api.lmsFinish()).toEqual("true");   // "should fail" ... asserts success
});
```

A throttle test in `Scorm12API.additional.spec.ts` was passing only *because* uninitialized commits wrongly succeeded — it never reached the throttle path it claimed to test. It now initializes first.

New `F3`–`F5` probes in `scorm12-divergence-probes.json` cover every fix, following the existing fixture pattern. The `F3` steps include the exclusive bound on the `_count` carve-out; widening that check from `===` to `>=` was verified to make them fail, so they catch the regression rather than merely passing.

```
196 test files / 6914 tests / 0 failures
40 ADL conformance fixtures / 0 failures (37 SCORM 2004 + 1.2 probes)
npm run lint, tsc --noEmit: clean
```

## Deliberate divergences left alone

`suspend_data` accepting >4096 chars (`CMIString64000`), unbounded `CMITimespan` hours, unknown elements mapping uniformly to `401` rather than ADL's `201`/`401` split (probe `P4`), and objective identifiers containing spaces (probe `P6`).

## Context

`test/conformance/adl/SCORM12_COVERAGE.md` notes that the 1.2 side has no externalized command grammar to decode, so its coverage is hand-authored probes rather than ADL-derived fixtures — and warns this is the same author-bias gap that let two 2004 bugs survive the unit suite. These five are that gap made concrete: all four defects live in code paths the 222-file suite exercises, but the assertions encoded the implementation's behavior rather than ADL's.