### PR TITLE
fix(scorm2004): align sequencing navigation and rollup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -153,7 +153,7 @@ jobs:
         run: npx tsc --noEmit
 
       - name: Dependency vulnerability scanning
-        run: npm audit --level=moderate
+        run: npm audit --audit-level=moderate
 
       # Upload build artifacts for integration tests
       - name: Upload build artifacts

--- a/package-lock.json
+++ b/package-lock.json
@@ -4458,9 +4458,9 @@
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7654,13 +7654,14 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -8349,15 +8350,15 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },

--- a/src/cmi/scorm2004/sequencing/activity.ts
+++ b/src/cmi/scorm2004/sequencing/activity.ts
@@ -709,7 +709,7 @@ export class Activity extends BaseCMI {
   private _objectiveSatisfiedStatusKnown: boolean = false;
   private _objectiveMeasureStatus: boolean = false;
   private _objectiveNormalizedMeasure: number = 0;
-  private _scaledPassingScore: number = 0.7; // Default passing score
+  private _scaledPassingScore: number = 1.0; // SCORM default minimum normalized measure
 
   // Dirty flags for tracking which activity-level objective properties have been modified locally
   private _objectiveSatisfiedStatusDirty: boolean = false;
@@ -2140,6 +2140,9 @@ export class Activity extends BaseCMI {
       this._objectiveSatisfiedStatusDirty = true;
     }
     this._objectiveSatisfiedStatusKnown = objectiveProgressStatus;
+    if (objectiveProgressStatus) {
+      this._successStatus = satisfiedStatus ? SuccessStatus.PASSED : SuccessStatus.FAILED;
+    }
     if (this._objectiveMeasureStatus !== measureStatus) {
       this._objectiveMeasureStatus = measureStatus;
       this._objectiveMeasureStatusDirty = true;

--- a/src/cmi/scorm2004/sequencing/handlers/rte_data_transfer.ts
+++ b/src/cmi/scorm2004/sequencing/handlers/rte_data_transfer.ts
@@ -321,6 +321,11 @@ export class RteDataTransferService {
         (cmiData.success_status_was_set === undefined &&
           topLevelSuccessStatus !== null &&
           topLevelSuccessStatus !== SuccessStatus.UNKNOWN);
+      const topLevelPrimaryScoreWasSet =
+        cmiData.score_was_set === true ||
+        (cmiData.score_was_set === undefined &&
+          cmiData.score !== undefined &&
+          this.normalizeScore(cmiData.score) !== null);
 
       // Transfer success status. Read-mapped values remain valid write-map
       // sources even when the SCO leaves them untouched. The one conflicting
@@ -371,7 +376,11 @@ export class RteDataTransferService {
       }
 
       // Transfer score (with normalization)
-      if (cmiObjective.score) {
+      const objectiveScoreMayOverridePrimary =
+        cmiObjective.score_was_set !== false ||
+        !isPrimaryObjective ||
+        !topLevelPrimaryScoreWasSet;
+      if (cmiObjective.score && objectiveScoreMayOverridePrimary) {
         // @spec SCORM 2004 4th Ed. ADLSEQ objectives extension - raw/min/max
         // score write maps use the RTE objective score values, independent of scaled score.
         activityObjective.initializeScoreFromCMI(this.getObjectiveScoreState(cmiObjective.score));

--- a/src/cmi/scorm2004/sequencing/handlers/termination_handler.ts
+++ b/src/cmi/scorm2004/sequencing/handlers/termination_handler.ts
@@ -971,7 +971,7 @@ export class TerminationHandler {
 
     // Trigger rollup after global objective sync
     // Rollup calculates satisfaction and completion based on children and global state
-    this.rollupProcess.overallRollupProcess(activity);
+    this.rollupProcess.overallRollupProcess(activity, this.globalObjectiveMap);
 
     // Rollup can recalculate an active cluster's primary objective from its
     // children. Reapply only the fields written by this terminating descendant
@@ -981,11 +981,17 @@ export class TerminationHandler {
     activeAncestor = activity.parent;
     while (activeAncestor) {
       if (activeAncestor.isActive) {
-        this.rollupProcess.syncFreshlyWrittenObjectivesToActiveAncestor(
+        const mappedStateChanged = this.rollupProcess.syncFreshlyWrittenObjectivesToActiveAncestor(
           activeAncestor,
           this.globalObjectiveMap,
           writeTargets,
         );
+        if (mappedStateChanged) {
+          // The ancestor's read-mapped primary is authoritative over its descendant aggregate.
+          // Propagate that restored state through its parents after the descendant rollup above.
+          // @spec SCORM 2004 4th Ed. SN SM.7 and RB.1.5
+          this.rollupProcess.overallRollupProcess(activeAncestor, this.globalObjectiveMap);
+        }
       }
       activeAncestor = activeAncestor.parent;
     }
@@ -1025,11 +1031,10 @@ export class TerminationHandler {
     const primaryObjectiveId = activity.primaryObjective?.id;
     return Boolean(
       primaryObjectiveId &&
-        cmiData.objectives?.some(
-          (objective) =>
-            objective.id === primaryObjectiveId &&
-            objective.success_status_was_set === true,
-        ),
+      cmiData.objectives?.some(
+        (objective) =>
+          objective.id === primaryObjectiveId && objective.success_status_was_set === true,
+      ),
     );
   }
 

--- a/src/cmi/scorm2004/sequencing/navigation_look_ahead.ts
+++ b/src/cmi/scorm2004/sequencing/navigation_look_ahead.ts
@@ -164,59 +164,21 @@ export class NavigationLookAhead {
    * @private
    */
   private predictContinueInternal(currentActivity: Activity): boolean {
-    // Check basic flow control requirements
+    // NB.2.1 only requires the current activity to be in a flow-enabled
+    // cluster. Do not inspect the next activity here: ending the current
+    // attempt transfers its RTE data, writes global objectives, and can change
+    // the next activity's precondition result before flow traversal begins.
+    //
+    // The ADL Sample RTE follows the same rule and always exposes Continue for
+    // an activity in a flow cluster. Trying to predict the post-termination
+    // target from the pre-termination tree can otherwise deadlock content that
+    // relies on its final cmi.completion_status/cmi.success_status write to
+    // unlock the next SCO.
     if (!currentActivity.parent) {
       return false;
     }
 
-    // Flow must be enabled on the parent to use Continue
-    if (!currentActivity.parent.sequencingControls.flow) {
-      return false;
-    }
-
-    // Check if there's a potential next activity
-    // We can't fully simulate the flow process without side effects,
-    // so we do a simplified check
-    return this.hasAvailableNextActivity(currentActivity);
-  }
-
-  /**
-   * Check if there's an available next activity in flow
-   * @param {Activity} currentActivity - Current activity
-   * @return {boolean} - True if next activity exists
-   * @private
-   */
-  private hasAvailableNextActivity(currentActivity: Activity): boolean {
-    const parent = currentActivity.parent;
-    if (!parent) {
-      return false;
-    }
-
-    const siblings = parent.children;
-    const currentIndex = siblings.indexOf(currentActivity);
-
-    if (currentIndex === -1) {
-      return false;
-    }
-
-    // Check if there's any sibling after current
-    if (currentIndex < siblings.length - 1) {
-      // Check if there's a deliverable activity after this one
-      // Uses full preConditionRule evaluation for forward navigation
-      for (let i = currentIndex + 1; i < siblings.length; i++) {
-        const sibling = siblings[i];
-        if (sibling && this.isActivityPotentiallyDeliverableForward(sibling)) {
-          return true;
-        }
-      }
-    }
-
-    // Check if parent can be exited and has a next sibling
-    if (parent.parent && parent.sequencingControls.flow) {
-      return this.hasAvailableNextActivity(parent);
-    }
-
-    return false;
+    return currentActivity.parent.sequencingControls.flow;
   }
 
   /**
@@ -327,7 +289,7 @@ export class NavigationLookAhead {
     const validation = this.sequencingProcess.validateNavigationRequest(
       SequencingRequestType.CHOICE,
       activity.id,
-      currentActivity
+      currentActivity,
     );
 
     const isChoiceEnabled = validation.valid;
@@ -347,40 +309,6 @@ export class NavigationLookAhead {
   }
 
   /**
-   * Check if activity is potentially deliverable for forward navigation (Continue)
-   * This properly evaluates preConditionRules to determine if the activity can be delivered
-   * @param {Activity} activity - Activity to check
-   * @return {boolean} - True if potentially deliverable
-   * @private
-   */
-  private isActivityPotentiallyDeliverableForward(activity: Activity): boolean {
-    // isHiddenFromChoice blocks both choice and flow navigation
-    if (activity.isHiddenFromChoice || !activity.isAvailable) {
-      return false;
-    }
-
-    // For leaf activities, use the full check that evaluates preConditionRules
-    // isVisible only affects deliverability of leaf activities, not cluster traversal
-    if (activity.children.length === 0) {
-      if (!activity.isVisible) {
-        return false;
-      }
-      return this.sequencingProcess.canActivityBeDelivered(activity);
-    }
-
-    // For clusters, check if any child is potentially deliverable
-    // Note: Invisible clusters (isVisible=false) can still be traversed by flow navigation
-    // - they just won't appear in the TOC. This is a common pattern for grouping content.
-    for (const child of activity.children) {
-      if (this.isActivityPotentiallyDeliverableForward(child)) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-  /**
    * Check if activity is potentially deliverable for backward navigation (Previous)
    * This uses a simpler check that doesn't fully evaluate preConditionRules
    * since we're typically going back to a previously visited activity
@@ -389,20 +317,19 @@ export class NavigationLookAhead {
    * @private
    */
   private isActivityPotentiallyDeliverableBackward(activity: Activity): boolean {
-    // isHiddenFromChoice blocks both choice and flow navigation
-    if (activity.isHiddenFromChoice || !activity.isAvailable) {
+    // Visibility and hidden-from-choice only affect choice presentation. Flow
+    // navigation can still deliver the activity.
+    if (!activity.isAvailable) {
       return false;
     }
 
-    // For leaf activities, isVisible must be true to deliver
+    // For backward navigation, use a simpler check since a leaf was likely
+    // already delivered before (the learner is going back to review).
     if (activity.children.length === 0) {
-      // For backward navigation, we use a simpler check since the activity was likely
-      // already delivered before (the learner is going back to review)
-      return activity.isVisible;
+      return true;
     }
 
     // For clusters, check if any child is potentially deliverable
-    // Note: Invisible clusters can still be traversed by flow navigation
     for (const child of activity.children) {
       if (this.isActivityPotentiallyDeliverableBackward(child)) {
         return true;

--- a/src/cmi/scorm2004/sequencing/overall_sequencing_process.ts
+++ b/src/cmi/scorm2004/sequencing/overall_sequencing_process.ts
@@ -396,8 +396,11 @@ export class OverallSequencingProcess {
         navigationRequest: navigationRequest,
       });
 
-      // Return delivery request indicating session end
-      return new DeliveryRequest(false, null, seqResult.exception || "SESSION_ENDED");
+      // Reaching the end of forward flow successfully ends the sequencing session. The
+      // lower-level flow result may retain SB.2.7-2 to describe why no next activity was
+      // identified, but that diagnostic must not turn the successful session end into a
+      // learner-visible navigation failure.
+      return new DeliveryRequest(true, null);
     }
 
     if (seqResult.exception) {

--- a/src/cmi/scorm2004/sequencing/rollup/cross_cluster_processor.ts
+++ b/src/cmi/scorm2004/sequencing/rollup/cross_cluster_processor.ts
@@ -216,14 +216,13 @@ export class CrossClusterProcessor {
   public processClusterRollup(cluster: Activity, depth: number = 0): void {
     // Perform standard rollup process for the cluster
     const nestedClusters = this.measureProcessor.measureRollupProcess(cluster);
+    this.measureProcessor.completionMeasureRollupProcess(cluster);
 
-    if (cluster.sequencingControls.rollupObjectiveSatisfied) {
-      this.objectiveProcessor.objectiveRollupProcess(cluster);
-    }
-
-    if (cluster.sequencingControls.rollupProgressCompletion) {
-      this.progressProcessor.activityProgressRollupProcess(cluster);
-    }
+    // These controls determine whether the cluster contributes to its parent's rollup. They do
+    // not gate calculation of the cluster's own state; the child-filtering subprocess applies
+    // them to the appropriate children.
+    this.objectiveProcessor.objectiveRollupProcess(cluster);
+    this.progressProcessor.activityProgressRollupProcess(cluster);
 
     // Handle nested clusters with increased depth to prevent infinite recursion
     if (nestedClusters.length > 1) {

--- a/src/cmi/scorm2004/sequencing/rollup/measure_rollup.ts
+++ b/src/cmi/scorm2004/sequencing/rollup/measure_rollup.ts
@@ -52,10 +52,6 @@ export class MeasureRollupProcessor {
    * @returns Array of identified activity clusters (for cross-cluster processing)
    */
   public measureRollupProcess(activity: Activity): Activity[] {
-    if (!activity.sequencingControls.rollupObjectiveSatisfied) {
-      return [];
-    }
-
     const children = activity.getAvailableChildren();
     if (children.length === 0) {
       return [];

--- a/src/cmi/scorm2004/sequencing/rollup/objective_rollup.ts
+++ b/src/cmi/scorm2004/sequencing/rollup/objective_rollup.ts
@@ -122,7 +122,12 @@ export class ObjectiveRollupProcessor {
    * @returns True if satisfied, false if not, null if no measure
    */
   public objectiveRollupUsingMeasure(activity: Activity): boolean | null {
-    if (!activity.objectiveMeasureStatus || activity.scaledPassingScore === null) {
+    const primaryObjective = activity.primaryObjective;
+    if (
+      !primaryObjective?.satisfiedByMeasure ||
+      !activity.objectiveMeasureStatus ||
+      activity.scaledPassingScore === null
+    ) {
       return null;
     }
 

--- a/src/cmi/scorm2004/sequencing/rollup/rollup_rule_evaluator.ts
+++ b/src/cmi/scorm2004/sequencing/rollup/rollup_rule_evaluator.ts
@@ -1,5 +1,10 @@
 import { Activity } from "../activity";
-import { RollupActionType, RollupConsiderationType, RollupRule } from "../rollup_rules";
+import {
+  RollupActionType,
+  RollupConditionCombination,
+  RollupConsiderationType,
+  RollupRule,
+} from "../rollup_rules";
 import { RollupChildFilter } from "./rollup_child_filter";
 
 /**
@@ -123,10 +128,12 @@ export class RollupRuleEvaluator {
       return true;
     }
 
-    // Rollup conditions default to an "all" combination. childActivitySet controls how matching
-    // children are counted; it does not change how this individual child's conditions combine.
+    // rollupConditions defaults to "any". childActivitySet controls how matching children are
+    // counted; conditionCombination controls how one child's condition results combine.
     // @spec SCORM 2004 4th Ed. SN RB.1.4.1
-    return rule.conditions.every((condition) => condition.evaluate(child));
+    return rule.conditionCombination === RollupConditionCombination.ALL
+      ? rule.conditions.every((condition) => condition.evaluate(child))
+      : rule.conditions.some((condition) => condition.evaluate(child));
   }
 
   /**

--- a/src/cmi/scorm2004/sequencing/rollup_process.ts
+++ b/src/cmi/scorm2004/sequencing/rollup_process.ts
@@ -38,6 +38,13 @@ export type EventCallback = (eventType: string, data?: unknown) => void;
  * @spec SN Book: RB.1.5 (Overall Rollup Process)
  */
 export class RollupProcess {
+  /**
+   * Capability flag for hosts that supported older rollup behavior with a compatibility layer.
+   * Rollup contribution controls belong to an activity as a child of its parent; they do not gate
+   * calculation of the activity's own rolled-up state.
+   */
+  public readonly childContributionControlsApplyToParent = true;
+
   private childFilter: RollupChildFilter;
   private ruleEvaluator: RollupRuleEvaluator;
   private measureProcessor: MeasureRollupProcessor;
@@ -92,7 +99,10 @@ export class RollupProcess {
    * @param activity - The activity to start rollup from
    * @returns Array of activities that had status changes
    */
-  public overallRollupProcess(activity: Activity): Activity[] {
+  public overallRollupProcess(
+    activity: Activity,
+    globalObjectives?: Map<string, GlobalObjective>,
+  ): Activity[] {
     const affectedActivities: Activity[] = [];
     let currentActivity: Activity | null = activity.parent; // Start from parent, not the activity itself
     let onlyDurationRollup = false;
@@ -110,32 +120,40 @@ export class RollupProcess {
         // Capture status BEFORE rollup
         const beforeStatus = currentActivity.captureRollupStatus();
 
-        // Only perform rollup if the activity tracks status
-        if (
-          currentActivity.sequencingControls.rollupObjectiveSatisfied ||
-          currentActivity.sequencingControls.rollupProgressCompletion
-        ) {
-          // Step 1: Measure Rollup Process (RB.1.1)
-          if (currentActivity.children.length > 0) {
-            const clusters = this.measureProcessor.measureRollupProcess(currentActivity);
-            // Step 1b: Completion Measure Rollup Process (RB.1.1 b)
-            this.measureProcessor.completionMeasureRollupProcess(currentActivity);
+        // Step 1: Measure Rollup Process (RB.1.1)
+        if (currentActivity.children.length > 0) {
+          const clusters = this.measureProcessor.measureRollupProcess(currentActivity);
+          // Step 1b: Completion Measure Rollup Process (RB.1.1 b)
+          this.measureProcessor.completionMeasureRollupProcess(currentActivity);
 
-            // Process cross-cluster dependencies if dealing with multiple clusters
-            if (clusters.length > 1) {
-              this.crossClusterProcessor.processCrossClusterDependencies(currentActivity, clusters);
-            }
+          // Process cross-cluster dependencies if dealing with multiple clusters
+          if (clusters.length > 1) {
+            this.crossClusterProcessor.processCrossClusterDependencies(currentActivity, clusters);
           }
+        }
 
-          // Step 2: Objective Rollup Process (RB.1.2)
-          if (currentActivity.sequencingControls.rollupObjectiveSatisfied) {
-            this.objectiveProcessor.objectiveRollupProcess(currentActivity);
-          }
+        // The rollupObjectiveSatisfied and rollupProgressCompletion controls describe whether
+        // this activity contributes to its parent's rollup; they do not disable calculation of
+        // this activity's own rolled-up state. The child-filtering subprocess applies those
+        // controls to each contributing child (SCORM 2004 RB.1.4.2).
 
-          // Step 3: Activity Progress Rollup Process (RB.1.3)
-          if (currentActivity.sequencingControls.rollupProgressCompletion) {
-            this.progressProcessor.activityProgressRollupProcess(currentActivity);
-          }
+        // Step 2: Objective Rollup Process (RB.1.2)
+        this.objectiveProcessor.objectiveRollupProcess(currentActivity);
+
+        // Step 3: Activity Progress Rollup Process (RB.1.3)
+        this.progressProcessor.activityProgressRollupProcess(currentActivity);
+
+        // A primary objective read map is the activity's view of the shared objective. Restore
+        // that view after calculating this cluster and before its parent evaluates the cluster as
+        // a rollup child. Without this step, a later descendant rollup can replace a previously
+        // satisfied test-out objective with the descendant aggregate even though the mapped
+        // global objective remains satisfied.
+        // @spec SCORM 2004 4th Ed. SN 3.10.3 and RB.1.5
+        if (globalObjectives) {
+          this.globalObjectiveSynchronizer.syncGlobalObjectivesReadPhase(
+            currentActivity,
+            globalObjectives,
+          );
         }
 
         // Capture status AFTER rollup
@@ -230,7 +248,7 @@ export class RollupProcess {
       );
       const parent = changedActivity.parent;
       if (parent && !rolledUpParents.has(parent)) {
-        this.overallRollupProcess(changedActivity);
+        this.overallRollupProcess(changedActivity, globalObjectives);
         rolledUpParents.add(parent);
       }
     }
@@ -261,8 +279,8 @@ export class RollupProcess {
     activity: Activity,
     globalObjectives: Map<string, GlobalObjective>,
     writeTargets: GlobalObjectiveWriteTargets,
-  ): void {
-    this.globalObjectiveSynchronizer.syncFreshlyWrittenGlobalObjectivesReadPhase(
+  ): boolean {
+    return this.globalObjectiveSynchronizer.syncFreshlyWrittenGlobalObjectivesReadPhase(
       activity,
       globalObjectives,
       writeTargets,

--- a/src/cmi/scorm2004/sequencing/rollup_rules.ts
+++ b/src/cmi/scorm2004/sequencing/rollup_rules.ts
@@ -26,8 +26,25 @@ export enum RollupConditionType {
   COMPLETED = "completed",
   PROGRESS_KNOWN = "progressKnown",
   ATTEMPTED = "attempted",
+  ATTEMPT_LIMIT_EXCEEDED = "attemptLimitExceeded",
   NOT_ATTEMPTED = "notAttempted",
   ALWAYS = "always",
+}
+
+/**
+ * Enum for operators applied to individual rollup conditions
+ */
+export enum RollupConditionOperator {
+  NO_OP = "noOp",
+  NOT = "not",
+}
+
+/**
+ * Enum for combining the conditions within one rollup rule
+ */
+export enum RollupConditionCombination {
+  ALL = "all",
+  ANY = "any",
 }
 
 /**
@@ -47,19 +64,23 @@ export enum RollupConsiderationType {
 export class RollupCondition extends BaseCMI {
   private _condition: RollupConditionType = RollupConditionType.ALWAYS;
   private _parameters: Map<string, any> = new Map();
+  private _operator: RollupConditionOperator = RollupConditionOperator.NO_OP;
 
   /**
    * Constructor for RollupCondition
    * @param {RollupConditionType} condition - The condition type
    * @param {Map<string, any>} parameters - Additional parameters for the condition
+   * @param {RollupConditionOperator} operator - The operator applied to the condition result
    */
   constructor(
     condition: RollupConditionType = RollupConditionType.ALWAYS,
     parameters: Map<string, any> = new Map(),
+    operator: RollupConditionOperator = RollupConditionOperator.NO_OP,
   ) {
     super("rollupCondition");
     this._condition = condition;
     this._parameters = parameters;
+    this._operator = operator;
   }
 
   /**
@@ -102,6 +123,22 @@ export class RollupCondition extends BaseCMI {
   }
 
   /**
+   * Getter for the condition operator
+   * @return {RollupConditionOperator}
+   */
+  get operator(): RollupConditionOperator {
+    return this._operator;
+  }
+
+  /**
+   * Setter for the condition operator
+   * @param {RollupConditionOperator} operator
+   */
+  set operator(operator: RollupConditionOperator) {
+    this._operator = operator;
+  }
+
+  /**
    * Evaluate the condition for an activity
    * @param {Activity} activity - The activity to evaluate the condition for
    * @return {boolean} - True if the condition is met, false otherwise
@@ -114,54 +151,72 @@ export class RollupCondition extends BaseCMI {
     const objectiveInfoAvailable = activity.objectiveInfoAvailableInCurrentParentAttempt !== false;
     const progressInfoAvailable = activity.progressInfoAvailableInCurrentParentAttempt !== false;
 
+    let result: boolean;
+
     switch (this._condition) {
       case RollupConditionType.SATISFIED:
         // Per SCORM 2004 SN Book RB.1.4.1, the "satisfied" condition checks the
         // objective satisfaction status from the activity's tracked objective.
         // This is populated via global objective mapping (readSatisfiedStatus).
         // Also check successStatus for backward compatibility with leaf activities.
-        return (
+        result = (
           objectiveInfoAvailable &&
           (activity.objectiveSatisfiedStatus === true ||
             activity.successStatus === SuccessStatus.PASSED)
         );
+        break;
       case RollupConditionType.OBJECTIVE_STATUS_KNOWN:
         // Per SCORM 2004 SN Book RB.1.4.1, objectiveStatusKnown checks if
         // the objective's satisfaction status has been explicitly determined
-        return objectiveInfoAvailable && activity.objectiveSatisfiedStatusKnown;
+        result = objectiveInfoAvailable && activity.objectiveSatisfiedStatusKnown;
+        break;
       case RollupConditionType.OBJECTIVE_MEASURE_KNOWN:
         // Per SCORM 2004 SN Book RB.1.4.1, objectiveMeasureKnown checks if
         // the objective has a valid measure value
-        return objectiveInfoAvailable && activity.objectiveMeasureStatus;
+        result = objectiveInfoAvailable && activity.objectiveMeasureStatus;
+        break;
       case RollupConditionType.OBJECTIVE_MEASURE_GREATER_THAN: {
         const greaterThanValue = this._parameters.get("threshold") || 0;
-        return (
+        result = (
           objectiveInfoAvailable &&
           activity.objectiveMeasureStatus &&
           activity.objectiveNormalizedMeasure > greaterThanValue
         );
+        break;
       }
       case RollupConditionType.OBJECTIVE_MEASURE_LESS_THAN: {
         const lessThanValue = this._parameters.get("threshold") || 0;
-        return (
+        result = (
           objectiveInfoAvailable &&
           activity.objectiveMeasureStatus &&
           activity.objectiveNormalizedMeasure < lessThanValue
         );
+        break;
       }
       case RollupConditionType.COMPLETED:
-        return progressInfoAvailable && activity.isCompleted;
+        result = progressInfoAvailable && activity.isCompleted;
+        break;
       case RollupConditionType.PROGRESS_KNOWN:
-        return progressInfoAvailable && activity.completionStatus !== CompletionStatus.UNKNOWN;
+        result =
+          progressInfoAvailable && activity.completionStatus !== CompletionStatus.UNKNOWN;
+        break;
       case RollupConditionType.ATTEMPTED:
-        return progressInfoAvailable && activity.attemptCount > 0;
+        result = progressInfoAvailable && activity.attemptCount > 0;
+        break;
+      case RollupConditionType.ATTEMPT_LIMIT_EXCEEDED:
+        result = activity.hasAttemptLimitExceeded();
+        break;
       case RollupConditionType.NOT_ATTEMPTED:
-        return !progressInfoAvailable || activity.attemptCount === 0;
+        result = !progressInfoAvailable || activity.attemptCount === 0;
+        break;
       case RollupConditionType.ALWAYS:
-        return true;
+        result = true;
+        break;
       default:
-        return false;
+        result = false;
     }
+
+    return this._operator === RollupConditionOperator.NOT ? !result : result;
   }
 
   /**
@@ -172,6 +227,7 @@ export class RollupCondition extends BaseCMI {
     this.jsonString = true;
     const result = {
       condition: this._condition,
+      operator: this._operator,
       parameters: Object.fromEntries(this._parameters),
     };
     this.jsonString = false;
@@ -188,6 +244,7 @@ export class RollupRule extends BaseCMI {
   private _consideration: RollupConsiderationType = RollupConsiderationType.ALL;
   private _minimumCount: number = 0;
   private _minimumPercent: number = 0;
+  public conditionCombination?: RollupConditionCombination = RollupConditionCombination.ANY;
 
   /**
    * Constructor for RollupRule
@@ -195,18 +252,21 @@ export class RollupRule extends BaseCMI {
    * @param {RollupConsiderationType} consideration - How to consider child activities
    * @param {number} minimumCount - The minimum count for AT_LEAST_COUNT consideration
    * @param {number} minimumPercent - The minimum percent for AT_LEAST_PERCENT consideration
+   * @param {RollupConditionCombination} conditionCombination - How this rule's conditions combine
    */
   constructor(
     action: RollupActionType = RollupActionType.SATISFIED,
     consideration: RollupConsiderationType = RollupConsiderationType.ALL,
     minimumCount: number = 0,
     minimumPercent: number = 0,
+    conditionCombination: RollupConditionCombination = RollupConditionCombination.ANY,
   ) {
     super("rollupRule");
     this._action = action;
     this._consideration = consideration;
     this._minimumCount = minimumCount;
     this._minimumPercent = minimumPercent;
+    this.conditionCombination = conditionCombination;
   }
 
   /**
@@ -334,7 +394,12 @@ export class RollupRule extends BaseCMI {
 
     // Filter children that meet all conditions
     const matchingChildren = children.filter((child) => {
-      return this._conditions.every((condition) => condition.evaluate(child));
+      if (this._conditions.length === 0) {
+        return true;
+      }
+      return this.conditionCombination === RollupConditionCombination.ALL
+        ? this._conditions.every((condition) => condition.evaluate(child))
+        : this._conditions.some((condition) => condition.evaluate(child));
     });
 
     // Apply consideration
@@ -368,6 +433,7 @@ export class RollupRule extends BaseCMI {
       consideration: this._consideration,
       minimumCount: this._minimumCount,
       minimumPercent: this._minimumPercent,
+      conditionCombination: this.conditionCombination,
     };
     this.jsonString = false;
     return result;
@@ -525,6 +591,10 @@ export class RollupRules extends BaseCMI {
    * @private
    */
   private _objectiveRollupUsingMeasure(activity: Activity, children: Activity[]): boolean | null {
+    if (!activity.primaryObjective?.satisfiedByMeasure || activity.scaledPassingScore === null) {
+      return null;
+    }
+
     // Check if objective measure weight is properly configured
     const objectiveMeasureWeight = activity.sequencingControls.objectiveMeasureWeight;
     if (objectiveMeasureWeight <= 0) {

--- a/src/cmi/scorm2004/sequencing/traversal/flow_traversal_service.ts
+++ b/src/cmi/scorm2004/sequencing/traversal/flow_traversal_service.ts
@@ -476,11 +476,6 @@ export class FlowTraversalService {
       return false;
     }
 
-    // For leaf activities, check visibility
-    if (activity.children.length === 0 && !activity.isVisible) {
-      return false;
-    }
-
     // Check limit conditions
     if (this.ruleEngine.checkLimitConditions(activity)) {
       return false;

--- a/src/cmi/scorm2004/sequencing/validation/rollup_state_validator.ts
+++ b/src/cmi/scorm2004/sequencing/validation/rollup_state_validator.ts
@@ -106,6 +106,7 @@ export class RollupStateValidator {
 
     // Check satisfaction status consistency with measure (only when success status is known)
     if (
+      activity.primaryObjective?.satisfiedByMeasure === true &&
       activity.objectiveMeasureStatus &&
       activity.scaledPassingScore !== null &&
       activity.successStatus !== "unknown"

--- a/src/configuration/activity_tree_builder.ts
+++ b/src/configuration/activity_tree_builder.ts
@@ -200,8 +200,9 @@ export class ActivityTreeBuilder {
       }
       if (threshold.minProgressMeasure !== undefined) {
         activity.minProgressMeasure = threshold.minProgressMeasure;
-        activity.completionThreshold = threshold.minProgressMeasure.toString();
-      } else if (threshold.completedByMeasure) {
+      }
+      // A schema-default minimum is inert unless this activity derives completion from measure.
+      if (activity.completedByMeasure) {
         activity.completionThreshold = activity.minProgressMeasure.toString();
       }
       if (threshold.progressWeight !== undefined) {

--- a/src/configuration/sequencing_configuration_builder.ts
+++ b/src/configuration/sequencing_configuration_builder.ts
@@ -203,6 +203,7 @@ export class SequencingConfigurationBuilder {
       ruleSettings.consideration,
       ruleSettings.minimumCount,
       ruleSettings.minimumPercent,
+      ruleSettings.conditionCombination,
     );
 
     // Add conditions
@@ -210,6 +211,7 @@ export class SequencingConfigurationBuilder {
       const condition = new RollupCondition(
         conditionSettings.condition,
         new Map(Object.entries(conditionSettings.parameters || {})),
+        conditionSettings.operator,
       );
       rule.addCondition(condition);
     }
@@ -329,9 +331,15 @@ export class SequencingConfigurationBuilder {
                 if (condition.parameters) {
                   clonedCondition.parameters = { ...condition.parameters };
                 }
+                if (condition.operator !== undefined) {
+                  clonedCondition.operator = condition.operator;
+                }
                 return clonedCondition;
               }),
             };
+            if (rule.conditionCombination !== undefined) {
+              clonedRule.conditionCombination = rule.conditionCombination;
+            }
             if (rule.consideration !== undefined) {
               clonedRule.consideration = rule.consideration;
             }

--- a/src/serialization/scorm2004_data_serializer.ts
+++ b/src/serialization/scorm2004_data_serializer.ts
@@ -122,7 +122,46 @@ export class Scorm2004DataSerializer {
       }
     }
 
-    const scoreObject: ScoreObject = this.context.cmi?.score?.getScoreObject() || {};
+    // Structured top-level fields represent the LMS course result at the session boundary. The
+    // CMI export remains the active SCO's runtime data. A sequenced course can roll up to complete
+    // while its next/current SCO is still incomplete (for example, a successful pre-test), so a
+    // terminate commit must use the root activity's tracking state.
+    const sequencingRoot = terminateCommit
+      ? this.context.sequencingService?.getSequencingState().rootActivity
+      : null;
+    if (sequencingRoot) {
+      completionStatus = sequencingRoot.completionStatus ?? CompletionStatus.UNKNOWN;
+      successStatus = sequencingRoot.successStatus ?? SuccessStatus.UNKNOWN;
+    }
+
+    let scoreObject: ScoreObject = this.context.cmi?.score?.getScoreObject() || {};
+    if (sequencingRoot) {
+      const primaryObjective = sequencingRoot.primaryObjective;
+      const hasCourseScore =
+        sequencingRoot.objectiveMeasureStatus ||
+        primaryObjective?.rawScoreKnown === true ||
+        primaryObjective?.minScoreKnown === true ||
+        primaryObjective?.maxScoreKnown === true;
+
+      if (hasCourseScore) {
+        // At a sequencing boundary the active CMI model still belongs to one SCO. Report the
+        // root activity's rolled-up measure as the course score, just as the structured statuses
+        // above report the root rather than whichever SCO happened to terminate last.
+        scoreObject = {};
+        if (sequencingRoot.objectiveMeasureStatus) {
+          scoreObject.scaled = sequencingRoot.objectiveNormalizedMeasure;
+        }
+        if (primaryObjective?.rawScoreKnown) {
+          scoreObject.raw = Number(primaryObjective.rawScore);
+        }
+        if (primaryObjective?.minScoreKnown) {
+          scoreObject.min = Number(primaryObjective.minScore);
+        }
+        if (primaryObjective?.maxScoreKnown) {
+          scoreObject.max = Number(primaryObjective.maxScore);
+        }
+      }
+    }
     const commitObject: CommitObject = {
       completionStatus: completionStatus,
       successStatus: successStatus,

--- a/src/types/sequencing_types.ts
+++ b/src/types/sequencing_types.ts
@@ -10,6 +10,8 @@ import {
 } from "../cmi/scorm2004/sequencing/sequencing_rules";
 import {
   RollupActionType,
+  RollupConditionCombination,
+  RollupConditionOperator,
   RollupConditionType,
   RollupConsiderationType,
 } from "../cmi/scorm2004/sequencing/rollup_rules";
@@ -212,6 +214,7 @@ export type SequencingCollectionSettings = {
  */
 export type RollupConditionSettings = {
   condition: RollupConditionType;
+  operator?: RollupConditionOperator;
   parameters?: Record<string, any>;
 };
 
@@ -220,6 +223,7 @@ export type RollupConditionSettings = {
  */
 export type RollupRuleSettings = {
   action: RollupActionType;
+  conditionCombination?: RollupConditionCombination;
   consideration?: RollupConsiderationType;
   minimumCount?: number;
   minimumPercent?: number;

--- a/test/api/Scorm2004API.sequencing.spec.ts
+++ b/test/api/Scorm2004API.sequencing.spec.ts
@@ -405,6 +405,42 @@ describe("SCORM 2004 API Sequencing Configuration Tests", () => {
       expect(apiInstance.lmsGetValue("cmi.completion_status")).toBe("completed");
     });
 
+    it("should not populate cmi.completion_threshold when completedByMeasure is false", () => {
+      const apiInstance = api({
+        sequencing: {
+          activityTree: {
+            id: "root",
+            title: "Root",
+            sequencingControls: {
+              flow: true,
+            },
+            children: [
+              {
+                id: "content-completed-sco",
+                title: "Content-completed SCO",
+                completionThreshold: {
+                  completedByMeasure: false,
+                  minProgressMeasure: 1,
+                  progressWeight: 0.1,
+                },
+              },
+            ],
+          },
+        },
+      });
+
+      expect(apiInstance.lmsInitialize("")).toBe("true");
+      expect(apiInstance.getSequencingState().currentActivity?.id).toBe("content-completed-sco");
+
+      apiInstance.reset();
+      expect(apiInstance.cmi.completion_threshold).toBe("");
+
+      expect(apiInstance.lmsInitialize("")).toBe("true");
+      expect(apiInstance.lmsSetValue("cmi.progress_measure", "0")).toBe("true");
+      expect(apiInstance.lmsSetValue("cmi.completion_status", "completed")).toBe("true");
+      expect(apiInstance.lmsGetValue("cmi.completion_status")).toBe("completed");
+    });
+
     it("should handle partial sequencing controls configuration", () => {
       const sequencingSettings = {
         sequencingControls: {

--- a/test/cmi/scorm2004/sequencing/advanced_rollup.spec.ts
+++ b/test/cmi/scorm2004/sequencing/advanced_rollup.spec.ts
@@ -14,7 +14,10 @@
 
 import { beforeEach, describe, expect, it } from "vitest";
 import { RollupProcess } from "../../../../src/cmi/scorm2004/sequencing/rollup_process";
-import { Activity } from "../../../../src/cmi/scorm2004/sequencing/activity";
+import {
+  Activity,
+  ActivityObjective
+} from "../../../../src/cmi/scorm2004/sequencing/activity";
 import {
   RollupActionType,
   RollupCondition,
@@ -1001,6 +1004,11 @@ describe("Advanced Rollup Configuration Tests", () => {
 
     it("should use measure-based rollup when scaledPassingScore is set", () => {
       // Set up measure rollup with explicit passing score
+      parent.primaryObjective = new ActivityObjective("primary", {
+        isPrimary: true,
+        satisfiedByMeasure: true,
+        minNormalizedMeasure: 0.7
+      });
       parent.scaledPassingScore = 0.7;
 
       // No rules added - will use measure rollup then default

--- a/test/cmi/scorm2004/sequencing/asset_only_default_rollup.spec.ts
+++ b/test/cmi/scorm2004/sequencing/asset_only_default_rollup.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import Scorm2004API from "../../../../src/Scorm2004API";
+import { LogLevelEnum } from "../../../../src/constants/enums";
+
+describe("asset-only default rollup", () => {
+  it("completes a nested activity tree when forward flow reaches the end", () => {
+    const clusterSizes = [6, 4, 5, 3];
+    const activityTree = {
+      id: "root",
+      title: "Asset course",
+      children: clusterSizes.map((size, clusterIndex) => ({
+        id: `cluster-${clusterIndex + 1}`,
+        title: `Cluster ${clusterIndex + 1}`,
+        children: Array.from({ length: size }, (_, leafIndex) => ({
+          id: `asset-${clusterIndex + 1}-${leafIndex + 1}`,
+          title: `Asset ${clusterIndex + 1}.${leafIndex + 1}`,
+        })),
+      })),
+    };
+    const api = new Scorm2004API({
+      autocommit: false,
+      logLevel: LogLevelEnum.NONE,
+      sequencing: { activityTree },
+    });
+    const sequencing = api.getSequencingService();
+
+    expect(sequencing).not.toBeNull();
+    expect(sequencing!.processNavigationRequest("start")).toBe(true);
+    for (let clusterIndex = 0; clusterIndex < clusterSizes.length; clusterIndex += 1) {
+      for (let leafIndex = 0; leafIndex < clusterSizes[clusterIndex]; leafIndex += 1) {
+        expect(
+          sequencing!.processNavigationRequest(
+            "choice",
+            `asset-${clusterIndex + 1}-${leafIndex + 1}`,
+          ),
+        ).toBe(true);
+      }
+    }
+    expect(sequencing!.getSequencingState().currentActivity?.id).toBe("asset-4-3");
+    expect(sequencing!.processNavigationRequest("choice", "asset-1-1")).toBe(true);
+    for (let index = 1; index < 18; index += 1) {
+      expect(sequencing!.processNavigationRequest("continue")).toBe(true);
+    }
+
+    expect(sequencing!.getSequencingState().currentActivity?.id).toBe("asset-4-3");
+    expect(sequencing!.processNavigationRequest("continue")).toBe(true);
+
+    const state = sequencing!.getSequencingState();
+    expect(state.rootActivity?.children.map((child) => child.completionStatus)).toEqual([
+      "completed",
+      "completed",
+      "completed",
+      "completed",
+    ]);
+    expect(state.rootActivity?.children.map((child) => child.successStatus)).toEqual([
+      "passed",
+      "passed",
+      "passed",
+      "passed",
+    ]);
+    expect(state.rootActivity?.completionStatus).toBe("completed");
+    expect(state.rootActivity?.successStatus).toBe("passed");
+
+    const commit = api.renderCommitObject(true);
+    expect(commit.completionStatus).toBe("completed");
+    expect(commit.successStatus).toBe("passed");
+  });
+});

--- a/test/cmi/scorm2004/sequencing/end_sequencing_session.spec.ts
+++ b/test/cmi/scorm2004/sequencing/end_sequencing_session.spec.ts
@@ -259,7 +259,7 @@ describe("EndSequencingSession Handling", () => {
       eventCallback.mockClear();
 
       // Execute: Continue past end
-      overallProcess.processNavigationRequest(NavigationRequestType.CONTINUE);
+      const delivery = overallProcess.processNavigationRequest(NavigationRequestType.CONTINUE);
 
       // Verify: Event should fire
       expect(eventCallback).toHaveBeenCalledWith(
@@ -269,6 +269,9 @@ describe("EndSequencingSession Handling", () => {
           exception: "SB.2.7-2"
         })
       );
+      expect(delivery.valid).toBe(true);
+      expect(delivery.targetActivity).toBeNull();
+      expect(delivery.exception).toBeNull();
     });
 
     it("should NOT fire onSequencingSessionEnd when session continues", () => {
@@ -472,7 +475,7 @@ describe("EndSequencingSession Handling", () => {
   });
 
   describe("Overall Sequencing Process Integration", () => {
-    it("should return appropriate DeliveryRequest when session ends", () => {
+    it("should return a successful DeliveryRequest when the session ends", () => {
       activityTree.currentActivity = sco3;
       sco3.isActive = false;
 
@@ -480,9 +483,10 @@ describe("EndSequencingSession Handling", () => {
         NavigationRequestType.CONTINUE
       );
 
-      // Verify: Delivery request indicates failure due to session end
-      expect(result.valid).toBe(false);
-      expect(result.exception).toBeTruthy();
+      // End of forward flow is a successful terminal outcome, not a navigation failure.
+      expect(result.valid).toBe(true);
+      expect(result.targetActivity).toBeNull();
+      expect(result.exception).toBeNull();
     });
 
     it("should handle session end after multiple successful navigations", () => {

--- a/test/cmi/scorm2004/sequencing/navigation_look_ahead.spec.ts
+++ b/test/cmi/scorm2004/sequencing/navigation_look_ahead.spec.ts
@@ -2,9 +2,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Activity } from "../../../../src/cmi/scorm2004/sequencing/activity";
 import { ActivityTree } from "../../../../src/cmi/scorm2004/sequencing/activity_tree";
 import { SequencingProcess } from "../../../../src/cmi/scorm2004/sequencing/sequencing_process";
+import { NavigationLookAhead } from "../../../../src/cmi/scorm2004/sequencing/navigation_look_ahead";
 import {
-  NavigationLookAhead
-} from "../../../../src/cmi/scorm2004/sequencing/navigation_look_ahead";
+  RuleActionType,
+  RuleCondition,
+  RuleConditionOperator,
+  RuleConditionType,
+  SequencingRule,
+} from "../../../../src/cmi/scorm2004/sequencing/sequencing_rules";
 
 describe("NavigationLookAhead", () => {
   let activityTree: ActivityTree;
@@ -51,7 +56,7 @@ describe("NavigationLookAhead", () => {
       expect(continueEnabled).toBe(true);
     });
 
-    it("should predict Continue disabled at last activity", () => {
+    it("should keep Continue enabled at the last activity in a flow cluster", () => {
       // Set up flow mode on root
       root.sequencingControls.flow = true;
 
@@ -59,7 +64,7 @@ describe("NavigationLookAhead", () => {
       activityTree.currentActivity = activity3;
 
       const continueEnabled = lookAhead.predictContinueEnabled();
-      expect(continueEnabled).toBe(false);
+      expect(continueEnabled).toBe(true);
     });
 
     it("should predict Continue disabled when flow not enabled", () => {
@@ -72,10 +77,31 @@ describe("NavigationLookAhead", () => {
       expect(continueEnabled).toBe(false);
     });
 
-    it("should predict Continue disabled when forwardOnly blocks", () => {
-      // This test is for a specific edge case where forwardOnly affects Continue
-      // In standard SCORM, forwardOnly affects Previous, not Continue
-      // But we'll test the current behavior
+    it("should not deadlock Continue on a precondition that can change at End Attempt", () => {
+      root.sequencingControls.flow = true;
+      activityTree.currentActivity = activity1;
+
+      // Before End Attempt, the next activity can still reflect stale global
+      // objective state. Continue itself remains valid; termination transfers
+      // the current SCO's final CMI data before sequencing evaluates activity2.
+      activity2.objectiveSatisfiedStatusKnown = true;
+      activity2.objectiveSatisfiedStatus = false;
+      const notSatisfied = new RuleCondition(
+        RuleConditionType.SATISFIED,
+        RuleConditionOperator.NOT,
+      );
+      const disabledRule = new SequencingRule(RuleActionType.DISABLED);
+      disabledRule.addCondition(notSatisfied);
+      activity2.sequencingRules.addPreConditionRule(disabledRule);
+
+      expect(activity2.sequencingRules.evaluatePreConditionRules(activity2)).toBe(
+        RuleActionType.DISABLED,
+      );
+
+      expect(lookAhead.predictContinueEnabled()).toBe(true);
+    });
+
+    it("should keep Continue enabled when forwardOnly blocks Previous", () => {
       root.sequencingControls.flow = true;
       root.sequencingControls.forwardOnly = true;
 
@@ -125,6 +151,15 @@ describe("NavigationLookAhead", () => {
 
       const previousEnabled = lookAhead.predictPreviousEnabled();
       expect(previousEnabled).toBe(false);
+    });
+
+    it("should allow Previous flow to an activity hidden from choice", () => {
+      root.sequencingControls.flow = true;
+      activity1.isVisible = false;
+      activity1.isHiddenFromChoice = true;
+      activityTree.currentActivity = activity2;
+
+      expect(lookAhead.predictPreviousEnabled()).toBe(true);
     });
   });
 
@@ -209,6 +244,7 @@ describe("NavigationLookAhead", () => {
 
       // Change activity
       activityTree.currentActivity = activity3;
+      root.sequencingControls.flow = false;
       lookAhead.invalidateCache();
 
       // Prediction should change
@@ -291,9 +327,10 @@ describe("NavigationLookAhead", () => {
       root.sequencingControls.flow = true;
       activityTree.currentActivity = activity3;
 
-      // Continue should be disabled at end
+      // A flow-enabled cluster keeps Continue valid so the request can end the
+      // sequencing session after the final activity.
       const continueEnabled = lookAhead.predictContinueEnabled();
-      expect(continueEnabled).toBe(false);
+      expect(continueEnabled).toBe(true);
     });
 
     it("should handle root is current activity", () => {

--- a/test/cmi/scorm2004/sequencing/navigation_look_ahead_edge_cases.spec.ts
+++ b/test/cmi/scorm2004/sequencing/navigation_look_ahead_edge_cases.spec.ts
@@ -80,7 +80,7 @@ describe("Navigation Look-Ahead Edge Cases", () => {
       expect(result).toBe(false);
     });
 
-    it("should predict continue disabled when activity is hidden from navigation", () => {
+    it("should keep continue enabled when the next activity is hidden", () => {
       const root = new Activity("root", "Root");
       const child1 = new Activity("child1", "Child 1");
       const child2 = new Activity("child2", "Child 2");
@@ -96,9 +96,8 @@ describe("Navigation Look-Ahead Edge Cases", () => {
 
       navigationLookAhead.updateCache();
 
-      // Continue might be disabled if next activity is hidden
       const result = navigationLookAhead.predictContinueEnabled();
-      expect(typeof result).toBe("boolean");
+      expect(result).toBe(true);
     });
 
     it("should handle cache invalidation correctly", () => {

--- a/test/cmi/scorm2004/sequencing/objective_dirty_tracking.spec.ts
+++ b/test/cmi/scorm2004/sequencing/objective_dirty_tracking.spec.ts
@@ -379,6 +379,7 @@ describe("Activity Objective Dirty Flag Tracking", () => {
       expect(activity.isObjectiveDirty("satisfiedStatus")).toBe(true);
       expect(activity.isObjectiveDirty("measureStatus")).toBe(true);
       expect(activity.isObjectiveDirty("normalizedMeasure")).toBe(true);
+      expect(activity.successStatus).toBe("passed");
     });
 
     it("should not set dirty flags when values unchanged", () => {

--- a/test/cmi/scorm2004/sequencing/objective_rollup_using_measure.spec.ts
+++ b/test/cmi/scorm2004/sequencing/objective_rollup_using_measure.spec.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { Activity } from "../../../../src/cmi/scorm2004/sequencing/activity";
+import {
+  Activity,
+  ActivityObjective
+} from "../../../../src/cmi/scorm2004/sequencing/activity";
 import {
   RollupActionType,
   RollupCondition,
@@ -19,6 +22,11 @@ describe("Objective Rollup Using Measure (RB.1.2.a)", () => {
   beforeEach(() => {
     // Create parent activity
     parentActivity = new Activity("parent", "Parent Activity");
+    parentActivity.primaryObjective = new ActivityObjective("primary", {
+      isPrimary: true,
+      satisfiedByMeasure: true,
+      minNormalizedMeasure: 0.7
+    });
     rollupRules = new RollupRules();
 
     // Create child activities

--- a/test/cmi/scorm2004/sequencing/overall_sequencing_process.spec.ts
+++ b/test/cmi/scorm2004/sequencing/overall_sequencing_process.spec.ts
@@ -20,6 +20,13 @@ import {
   SequencingRule,
   SequencingRules,
 } from "../../../../src/cmi/scorm2004/sequencing/sequencing_rules";
+import {
+  RollupActionType,
+  RollupCondition,
+  RollupConditionType,
+  RollupConsiderationType,
+  RollupRule,
+} from "../../../../src/cmi/scorm2004/sequencing/rollup_rules";
 
 describe("Overall Sequencing Process (OP.1)", () => {
   let overallProcess: OverallSequencingProcess;
@@ -2373,6 +2380,13 @@ describe("Overall Sequencing Process (OP.1)", () => {
         });
         child1.primaryObjective = ancestorObjective;
 
+        const rootCompletionRule = new RollupRule(
+          RollupActionType.SATISFIED,
+          RollupConsiderationType.ANY,
+        );
+        rootCompletionRule.addCondition(new RollupCondition(RollupConditionType.SATISFIED));
+        root.rollupRules.addRule(rootCompletionRule);
+
         const writerObjective = new ActivityObjective("writer-primary", {
           isPrimary: true,
           mapInfo: [
@@ -2418,6 +2432,8 @@ describe("Overall Sequencing Process (OP.1)", () => {
         expect(ancestorObjective.satisfiedStatusKnown).toBe(true);
         expect(child1.objectiveSatisfiedStatus).toBe(true);
         expect(child1.objectiveSatisfiedStatusKnown).toBe(true);
+        expect(root.objectiveSatisfiedStatus).toBe(true);
+        expect(root.successStatus).toBe("passed");
       });
 
       it("should trigger rollup after endAttemptProcess", () => {

--- a/test/cmi/scorm2004/sequencing/rollup/cross_cluster_processor.spec.ts
+++ b/test/cmi/scorm2004/sequencing/rollup/cross_cluster_processor.spec.ts
@@ -348,6 +348,7 @@ describe("CrossClusterProcessor", () => {
       processor.processClusterRollup(cluster);
 
       expect(mockMeasureProcessor.measureRollupProcess).toHaveBeenCalledWith(cluster);
+      expect(mockMeasureProcessor.completionMeasureRollupProcess).toHaveBeenCalledWith(cluster);
     });
 
     it("should call objective processor when rollupObjectiveSatisfied is true", () => {
@@ -363,7 +364,7 @@ describe("CrossClusterProcessor", () => {
       expect(mockObjectiveProcessor.objectiveRollupProcess).toHaveBeenCalledWith(cluster);
     });
 
-    it("should not call objective processor when rollupObjectiveSatisfied is false", () => {
+    it("should calculate objective state when the cluster does not contribute it to its parent", () => {
       const cluster = createMockActivity({
         id: "cluster",
         flow: false,
@@ -373,7 +374,7 @@ describe("CrossClusterProcessor", () => {
 
       processor.processClusterRollup(cluster);
 
-      expect(mockObjectiveProcessor.objectiveRollupProcess).not.toHaveBeenCalled();
+      expect(mockObjectiveProcessor.objectiveRollupProcess).toHaveBeenCalledWith(cluster);
     });
 
     it("should call progress processor when rollupProgressCompletion is true", () => {
@@ -389,7 +390,7 @@ describe("CrossClusterProcessor", () => {
       expect(mockProgressProcessor.activityProgressRollupProcess).toHaveBeenCalledWith(cluster);
     });
 
-    it("should not call progress processor when rollupProgressCompletion is false", () => {
+    it("should calculate progress state when the cluster does not contribute it to its parent", () => {
       const cluster = createMockActivity({
         id: "cluster",
         flow: false,
@@ -399,7 +400,7 @@ describe("CrossClusterProcessor", () => {
 
       processor.processClusterRollup(cluster);
 
-      expect(mockProgressProcessor.activityProgressRollupProcess).not.toHaveBeenCalled();
+      expect(mockProgressProcessor.activityProgressRollupProcess).toHaveBeenCalledWith(cluster);
     });
 
     it("should handle nested clusters by recursively calling processCrossClusterDependencies", () => {

--- a/test/cmi/scorm2004/sequencing/rollup/rollup_rule_evaluator.spec.ts
+++ b/test/cmi/scorm2004/sequencing/rollup/rollup_rule_evaluator.spec.ts
@@ -8,6 +8,9 @@ import {
 import { Activity } from "../../../../../src/cmi/scorm2004/sequencing/activity";
 import {
   RollupActionType,
+  RollupCondition,
+  RollupConditionCombination,
+  RollupConditionType,
   RollupConsiderationType,
   RollupRule
 } from "../../../../../src/cmi/scorm2004/sequencing/rollup_rules";
@@ -57,6 +60,7 @@ describe("RollupRuleEvaluator", () => {
 
         const rule: RollupRule = {
           action: RollupActionType.SATISFIED,
+          conditionCombination: RollupConditionCombination.ALL,
           consideration: RollupConsiderationType.ALL,
           conditions: [],
           minimumCount: null,
@@ -304,6 +308,37 @@ describe("RollupRuleEvaluator", () => {
       expect(result).toBe(true);
     });
 
+    it("should OR conditions when conditionCombination is any", () => {
+      child1.objectiveSatisfiedStatus = true;
+      child1.attemptLimit = 2;
+      child1.attemptCount = 1;
+
+      const rule = new RollupRule(
+        RollupActionType.COMPLETED,
+        RollupConsiderationType.ANY,
+        0,
+        0,
+        RollupConditionCombination.ANY
+      );
+      rule.addCondition(new RollupCondition(RollupConditionType.SATISFIED));
+      rule.addCondition(new RollupCondition(RollupConditionType.ATTEMPT_LIMIT_EXCEEDED));
+
+      expect(evaluator.evaluateRollupConditionsSubprocess(child1, rule)).toBe(true);
+      expect(evaluator.evaluateRollupRule(parent, rule)).toBe(true);
+
+      rule.conditionCombination = RollupConditionCombination.ALL;
+      expect(evaluator.evaluateRollupConditionsSubprocess(child1, rule)).toBe(false);
+      expect(evaluator.evaluateRollupRule(parent, rule)).toBe(false);
+
+      // The Random Test manifest's alternate branch completes after the learner
+      // exhausts the post-test attempt limit, even when the test is not satisfied.
+      child1.objectiveSatisfiedStatus = false;
+      child1.attemptCount = 2;
+      rule.conditionCombination = RollupConditionCombination.ANY;
+      expect(evaluator.evaluateRollupConditionsSubprocess(child1, rule)).toBe(true);
+      expect(evaluator.evaluateRollupRule(parent, rule)).toBe(true);
+    });
+
     describe("with ALL consideration", () => {
       it("should return true when all conditions are met", () => {
         const condition1 = createMockCondition(() => true);
@@ -328,6 +363,7 @@ describe("RollupRuleEvaluator", () => {
 
         const rule: RollupRule = {
           action: RollupActionType.SATISFIED,
+          conditionCombination: RollupConditionCombination.ALL,
           consideration: RollupConsiderationType.ALL,
           conditions: [condition1, condition2],
           minimumCount: null,
@@ -347,6 +383,7 @@ describe("RollupRuleEvaluator", () => {
 
         const rule: RollupRule = {
           action: RollupActionType.SATISFIED,
+          conditionCombination: RollupConditionCombination.ALL,
           consideration: RollupConsiderationType.ANY,
           conditions: [condition1, condition2],
           minimumCount: null,
@@ -385,6 +422,7 @@ describe("RollupRuleEvaluator", () => {
 
         const rule: RollupRule = {
           action: RollupActionType.SATISFIED,
+          conditionCombination: RollupConditionCombination.ALL,
           consideration: RollupConsiderationType.NONE,
           conditions: [condition1, condition2],
           minimumCount: null,
@@ -403,6 +441,7 @@ describe("RollupRuleEvaluator", () => {
 
         const rule: RollupRule = {
           action: RollupActionType.SATISFIED,
+          conditionCombination: RollupConditionCombination.ALL,
           consideration: RollupConsiderationType.NONE,
           conditions: [condition1, condition2],
           minimumCount: null,

--- a/test/cmi/scorm2004/sequencing/rollup_processes.spec.ts
+++ b/test/cmi/scorm2004/sequencing/rollup_processes.spec.ts
@@ -4,6 +4,7 @@ import { Activity, ActivityObjective } from "../../../../src/cmi/scorm2004/seque
 import {
   RollupActionType,
   RollupCondition,
+  RollupConditionCombination,
   RollupConditionType,
   RollupConsiderationType,
   RollupRule
@@ -49,10 +50,16 @@ describe("Rollup Processes (RB.1.1-1.5)", () => {
     it("should rollup from activity to root", () => {
       // Set child states
       child1.objectiveSatisfiedStatus = true;
+      child1.objectiveMeasureStatus = true;
+      child1.objectiveNormalizedMeasure = 0.9;
       child1.isCompleted = true;
       child2.objectiveSatisfiedStatus = true;
+      child2.objectiveMeasureStatus = true;
+      child2.objectiveNormalizedMeasure = 0.9;
       child2.isCompleted = true;
       child3.objectiveSatisfiedStatus = true;
+      child3.objectiveMeasureStatus = true;
+      child3.objectiveNormalizedMeasure = 0.9;
       child3.isCompleted = true;
 
       // Trigger overall rollup from child1
@@ -60,6 +67,8 @@ describe("Rollup Processes (RB.1.1-1.5)", () => {
 
       // Parent should be satisfied and completed
       expect(parent.objectiveSatisfiedStatus).toBe(true);
+      expect(parent.objectiveMeasureStatus).toBe(true);
+      expect(parent.objectiveNormalizedMeasure).toBeCloseTo(0.9);
       expect(parent.isCompleted).toBe(true);
 
       // Root should also be satisfied and completed
@@ -67,18 +76,28 @@ describe("Rollup Processes (RB.1.1-1.5)", () => {
       expect(root.isCompleted).toBe(true);
     });
 
-    it("should stop at activity with rollup disabled", () => {
+    it("should calculate an activity's state even when it does not contribute to its parent", () => {
       parent.sequencingControls.rollupObjectiveSatisfied = false;
       parent.sequencingControls.rollupProgressCompletion = false;
 
       child1.objectiveSatisfiedStatus = true;
       child1.isCompleted = true;
+      child2.objectiveSatisfiedStatus = true;
+      child2.isCompleted = true;
+      child3.objectiveSatisfiedStatus = true;
+      child3.isCompleted = true;
 
       rollupProcess.overallRollupProcess(child1);
 
-      // Parent should not be affected
-      expect(parent.objectiveSatisfiedStatus).toBe(false);
-      expect(parent.isCompleted).toBe(false);
+      // The controls belong to parent as a child of root. They do not suppress parent's own
+      // rollup from its children.
+      expect(parent.objectiveSatisfiedStatus).toBe(true);
+      expect(parent.isCompleted).toBe(true);
+
+      // Parent is excluded from root's objective and progress rollup.
+      expect(root.objectiveSatisfiedStatus).toBe(false);
+      expect(root.objectiveMeasureStatus).toBe(false);
+      expect(root.isCompleted).toBe(false);
     });
 
     it("should handle null parent gracefully", () => {
@@ -165,7 +184,11 @@ describe("Rollup Processes (RB.1.1-1.5)", () => {
   describe("Objective Rollup Process (RB.1.2)", () => {
     describe("Objective Rollup Using Measure (RB.1.2.a)", () => {
       it("should determine satisfaction from measure and passing score", () => {
-        parent.scaledPassingScore = 0.7;
+        parent.primaryObjective = new ActivityObjective("primary", {
+          isPrimary: true,
+          satisfiedByMeasure: true,
+          minNormalizedMeasure: 0.7,
+        });
 
         // Set up measure rollup
         child1.objectiveMeasureStatus = true;
@@ -183,7 +206,11 @@ describe("Rollup Processes (RB.1.1-1.5)", () => {
       });
 
       it("should fail when measure below passing score", () => {
-        parent.scaledPassingScore = 0.8;
+        parent.primaryObjective = new ActivityObjective("primary", {
+          isPrimary: true,
+          satisfiedByMeasure: true,
+          minNormalizedMeasure: 0.8,
+        });
 
         child1.objectiveMeasureStatus = true;
         child1.objectiveNormalizedMeasure = 0.6;
@@ -197,6 +224,28 @@ describe("Rollup Processes (RB.1.1-1.5)", () => {
         // Measure 0.6 < passing score 0.8
         expect(parent.objectiveSatisfiedStatus).toBe(false);
         expect(parent.successStatus).toBe(SuccessStatus.FAILED);
+      });
+
+      it("should use default satisfaction when the primary objective is not satisfied by measure", () => {
+        parent.primaryObjective = new ActivityObjective("assessment_satisfied", {
+          isPrimary: true,
+          satisfiedByMeasure: false,
+          minNormalizedMeasure: 0.7,
+        });
+
+        for (const child of [child1, child2, child3]) {
+          child.objectiveSatisfiedStatus = true;
+          child.objectiveMeasureStatus = true;
+          child.objectiveNormalizedMeasure = 0.13;
+        }
+
+        rollupProcess.overallRollupProcess(child1);
+
+        // The measure still rolls up, but satisfiedByMeasure=false means it cannot replace the
+        // children's explicit satisfied status.
+        expect(parent.objectiveNormalizedMeasure).toBeCloseTo(0.13);
+        expect(parent.objectiveSatisfiedStatus).toBe(true);
+        expect(parent.successStatus).toBe(SuccessStatus.PASSED);
       });
     });
 
@@ -425,7 +474,10 @@ describe("Rollup Processes (RB.1.1-1.5)", () => {
     it("should evaluate multiple conditions with ALL consideration", () => {
       const rule = new RollupRule(
         RollupActionType.SATISFIED,
-        RollupConsiderationType.ALL
+        RollupConsiderationType.ALL,
+        0,
+        0,
+        RollupConditionCombination.ALL
       );
       rule.addCondition(new RollupCondition(RollupConditionType.SATISFIED));
       rule.addCondition(new RollupCondition(RollupConditionType.COMPLETED));
@@ -929,7 +981,11 @@ describe("Rollup Processes (RB.1.1-1.5)", () => {
       measureParent.addChild(measureChild1);
       measureParent.addChild(measureChild2);
       measureParent.sequencingControls.rollupObjectiveSatisfied = true;
-      measureParent.scaledPassingScore = 0.7;
+      measureParent.primaryObjective = new ActivityObjective("primary", {
+        isPrimary: true,
+        satisfiedByMeasure: true,
+        minNormalizedMeasure: 0.7,
+      });
 
       // Set weights for measure rollup
       measureChild1.sequencingControls.objectiveMeasureWeight = 1.0;
@@ -1102,7 +1158,11 @@ describe("Rollup Processes (RB.1.1-1.5)", () => {
       });
 
       it("should satisfy when measure exactly equals passing score", () => {
-        parent.scaledPassingScore = 0.75;
+        parent.primaryObjective = new ActivityObjective("primary", {
+          isPrimary: true,
+          satisfiedByMeasure: true,
+          minNormalizedMeasure: 0.75,
+        });
 
         child1.objectiveMeasureStatus = true;
         child1.objectiveNormalizedMeasure = 0.75;
@@ -1548,6 +1608,49 @@ describe("Rollup Processes (RB.1.1-1.5)", () => {
         expect(mappedCluster.objectiveSatisfiedStatusKnown).toBe(true);
       });
 
+      it("preserves an already-read mapped primary during a later descendant rollup", () => {
+        const rootAct = new Activity("root", "Root");
+        const mappedCluster = new Activity("mapped-cluster", "Mapped Cluster");
+        const mappedChild = new Activity("mapped-child", "Mapped Child");
+        rootAct.addChild(mappedCluster);
+        mappedCluster.addChild(mappedChild);
+
+        mappedCluster.primaryObjective = new ActivityObjective("assessment-satisfied", {
+          isPrimary: true,
+          mapInfo: [{
+            targetObjectiveID: "assessment-global",
+            readSatisfiedStatus: true,
+            writeSatisfiedStatus: false,
+          }],
+        });
+        globalObjectives.set("assessment-global", {
+          id: "assessment-global",
+          satisfiedStatus: true,
+          satisfiedStatusKnown: true,
+          normalizedMeasure: 1,
+          normalizedMeasureKnown: true,
+        });
+
+        const rootCompletionRule = new RollupRule(
+          RollupActionType.COMPLETED,
+          RollupConsiderationType.ANY,
+        );
+        rootCompletionRule.addCondition(new RollupCondition(RollupConditionType.SATISFIED));
+        rootAct.rollupRules.addRule(rootCompletionRule);
+
+        // Seed the mapped cluster as a pre-test would, then perform a later rollup from an
+        // incomplete content descendant. The mapped global remains the source of satisfaction.
+        rollupProcess.processGlobalObjectiveMapping(rootAct, globalObjectives);
+        mappedChild.objectiveSatisfiedStatus = false;
+        mappedChild.completionStatus = CompletionStatus.INCOMPLETE;
+        rollupProcess.overallRollupProcess(mappedChild, globalObjectives);
+
+        expect(mappedCluster.objectiveSatisfiedStatusKnown).toBe(true);
+        expect(mappedCluster.objectiveSatisfiedStatus).toBe(true);
+        expect(mappedCluster.successStatus).toBe(SuccessStatus.PASSED);
+        expect(rootAct.completionStatus).toBe(CompletionStatus.COMPLETED);
+      });
+
       it("should not roll up an untracked read-mapped activity", () => {
         const rootAct = new Activity("root", "Root");
         const sourceAct = new Activity("source", "Source");
@@ -1708,9 +1811,13 @@ describe("Rollup Processes (RB.1.1-1.5)", () => {
     });
 
     it("should detect inconsistent satisfaction with measure", () => {
+      parent.primaryObjective = new ActivityObjective("primary", {
+        isPrimary: true,
+        satisfiedByMeasure: true,
+        minNormalizedMeasure: 0.7,
+      });
       parent.objectiveMeasureStatus = true;
       parent.objectiveNormalizedMeasure = 0.8;
-      parent.scaledPassingScore = 0.7;
       parent.objectiveSatisfiedStatus = false; // Should be true (0.8 >= 0.7)
       parent.successStatus = SuccessStatus.FAILED;
 

--- a/test/cmi/scorm2004/sequencing/rollup_rules.spec.ts
+++ b/test/cmi/scorm2004/sequencing/rollup_rules.spec.ts
@@ -4,6 +4,8 @@ import { describe, expect, it } from "vitest";
 import {
   RollupActionType,
   RollupCondition,
+  RollupConditionCombination,
+  RollupConditionOperator,
   RollupConditionType,
   RollupConsiderationType,
   RollupRule,
@@ -19,7 +21,24 @@ describe("RollupRules", () => {
       it("should initialize with default values", () => {
         const condition = new RollupCondition();
         expect(condition.condition).toBe(RollupConditionType.ALWAYS);
+        expect(condition.operator).toBe(RollupConditionOperator.NO_OP);
         expect(condition.parameters.size).toBe(0);
+      });
+
+      it("should apply NOT and evaluate attempt-limit conditions", () => {
+        const activity = new Activity("limited", "Limited Activity");
+        activity.attemptLimit = 2;
+        activity.attemptCount = 2;
+
+        const exceeded = new RollupCondition(RollupConditionType.ATTEMPT_LIMIT_EXCEEDED);
+        const notExceeded = new RollupCondition(
+          RollupConditionType.ATTEMPT_LIMIT_EXCEEDED,
+          new Map(),
+          RollupConditionOperator.NOT
+        );
+
+        expect(exceeded.evaluate(activity)).toBe(true);
+        expect(notExceeded.evaluate(activity)).toBe(false);
       });
 
       it("should initialize with provided values", () => {
@@ -58,6 +77,19 @@ describe("RollupRules", () => {
 
         activity.successStatus = SuccessStatus.UNKNOWN;
         expect(condition.evaluate(activity)).toBe(false);
+      });
+
+      it("should negate a known unsatisfied condition", () => {
+        const condition = new RollupCondition(
+          RollupConditionType.SATISFIED,
+          new Map(),
+          RollupConditionOperator.NOT
+        );
+        const activity = new Activity();
+        activity.objectiveSatisfiedStatus = false;
+        activity.successStatus = SuccessStatus.FAILED;
+
+        expect(condition.evaluate(activity)).toBe(true);
       });
 
       it("should evaluate OBJECTIVE_MEASURE_GREATER_THAN condition", () => {
@@ -150,6 +182,7 @@ describe("RollupRules", () => {
         expect(rule.consideration).toBe(RollupConsiderationType.ALL);
         expect(rule.minimumCount).toBe(0);
         expect(rule.minimumPercent).toBe(0);
+        expect(rule.conditionCombination).toBe(RollupConditionCombination.ANY);
         expect(rule.conditions).toEqual([]);
       });
 

--- a/test/cmi/scorm2004/sequencing/rte_data_transfer.spec.ts
+++ b/test/cmi/scorm2004/sequencing/rte_data_transfer.spec.ts
@@ -478,6 +478,56 @@ describe("RTE Data Transfer", () => {
       expect(leafActivity.successStatus).toBe("failed");
     });
 
+    it("should not let a launch-seeded primary objective override a top-level content score", () => {
+      const transfer = new RteDataTransferService({
+        getCMIData: null,
+        fireEvent: () => undefined,
+      });
+      const primaryObjective = leafActivity.primaryObjective!;
+      primaryObjective.satisfiedByMeasure = false;
+      primaryObjective.applyReadMappedState({
+        satisfiedStatus: false,
+        normalizedMeasure: 0.13,
+      });
+      primaryObjective.applyToActivity(leafActivity);
+
+      const cmiData: CMIDataForTransfer = {
+        completion_status: "completed",
+        success_status: "passed",
+        success_status_was_set: true,
+        score_was_set: true,
+        score: {
+          raw: "100",
+          min: "0",
+          max: "100",
+          scaled: "1",
+        },
+        objectives: [
+          {
+            id: "primary_obj",
+            success_status: "failed",
+            success_status_was_set: false,
+            score_was_set: false,
+            score: {
+              scaled: "0.13",
+            },
+          },
+        ],
+      };
+
+      transfer.transferPrimaryObjective(leafActivity, cmiData);
+      transfer.transferNonPrimaryObjectives(leafActivity, cmiData);
+
+      // A primary objective row initialized from its read map is an RTE view, not a SCO write.
+      // Once content writes cmi.score, that top-level primary score is authoritative.
+      expect(primaryObjective.normalizedMeasure).toBe(1);
+      expect(primaryObjective.measureStatus).toBe(true);
+      expect(primaryObjective.rawScore).toBe("100");
+      expect(primaryObjective.satisfiedStatus).toBe(true);
+      expect(leafActivity.objectiveNormalizedMeasure).toBe(1);
+      expect(leafActivity.successStatus).toBe("passed");
+    });
+
     it("should retain a launch-seeded primary status when content leaves both views untouched", () => {
       const transfer = new RteDataTransferService({
         getCMIData: null,

--- a/test/cmi/scorm2004/sequencing/satisfaction_by_measure.spec.ts
+++ b/test/cmi/scorm2004/sequencing/satisfaction_by_measure.spec.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { RollupProcess } from "../../../../src/cmi/scorm2004/sequencing/rollup_process";
-import { Activity } from "../../../../src/cmi/scorm2004/sequencing/activity";
+import {
+  Activity,
+  ActivityObjective
+} from "../../../../src/cmi/scorm2004/sequencing/activity";
 import { SuccessStatus } from "../../../../src/constants/enums";
 
 /**
@@ -21,6 +24,11 @@ describe("Satisfaction By Measure Edge Cases (RB.1.2.a)", () => {
 
     // Create simple parent-child structure
     parent = new Activity("parent", "Parent Activity");
+    parent.primaryObjective = new ActivityObjective("primary", {
+      isPrimary: true,
+      satisfiedByMeasure: true,
+      minNormalizedMeasure: 0.7
+    });
     child = new Activity("child", "Child Activity");
 
     parent.addChild(child);

--- a/test/cmi/scorm2004/sequencing/sequencing_process.spec.ts
+++ b/test/cmi/scorm2004/sequencing/sequencing_process.spec.ts
@@ -1873,7 +1873,7 @@ describe("SequencingProcess", () => {
   });
 
   describe("additional flow traversal edge cases", () => {
-    it("should handle mixed visible/hidden siblings in flow", () => {
+    it("should deliver an invisible sibling but skip an unavailable sibling in flow", () => {
       const tree = new ActivityTree();
       const root = new Activity("root", "Root");
       const child1 = new Activity("child1", "Child 1");
@@ -1888,7 +1888,7 @@ describe("SequencingProcess", () => {
 
       root.sequencingControls.flow = true;
 
-      // Make middle children invisible/unavailable
+      // Visibility only affects choice presentation; availability blocks delivery.
       child2.isVisible = false;
       child3.isAvailable = false;
 
@@ -1903,11 +1903,11 @@ describe("SequencingProcess", () => {
         new ADLNav()
       );
 
-      // Should skip hidden/unavailable and go to child4
+      // Flow delivers the invisible activity before reaching the unavailable one.
       const result = process.sequencingRequestProcess(SequencingRequestType.CONTINUE);
 
       expect(result.deliveryRequest).toBe(DeliveryRequestType.DELIVER);
-      expect(result.targetActivity?.id).toBe("child4");
+      expect(result.targetActivity?.id).toBe("child2");
     });
 
     it("should handle all siblings unavailable during flow", () => {

--- a/test/cmi/scorm2004/sequencing/termination_request_process.spec.ts
+++ b/test/cmi/scorm2004/sequencing/termination_request_process.spec.ts
@@ -96,7 +96,7 @@ describe("Termination Request Process (TB.2.3)", () => {
       const result = overallProcess.processNavigationRequest(NavigationRequestType.EXIT);
 
       expect(result.valid).toBe(true);
-      expect(rollupSpy).toHaveBeenCalledWith(grandchild1);
+      expect(rollupSpy).toHaveBeenCalledWith(grandchild1, expect.any(Map));
     });
   });
 

--- a/test/cmi/scorm2004/sequencing/traversal/flow_traversal_service.spec.ts
+++ b/test/cmi/scorm2004/sequencing/traversal/flow_traversal_service.spec.ts
@@ -253,7 +253,7 @@ describe("FlowTraversalService", () => {
       expect(activity2.wasSkipped).toBe(true);
     });
 
-    it("should return null for invisible leaf activity", () => {
+    it("should deliver an invisible leaf through flow navigation", () => {
       lesson1.isVisible = false;
 
       const result = service.flowActivityTraversalSubprocess(
@@ -262,7 +262,7 @@ describe("FlowTraversalService", () => {
         true,
         FlowSubprocessMode.FORWARD,
       );
-      expect(result).toBeNull();
+      expect(result).toBe(lesson1);
     });
   });
 
@@ -308,9 +308,9 @@ describe("FlowTraversalService", () => {
       expect(service.checkActivityProcess(lesson1)).toBe(false);
     });
 
-    it("should return false for invisible leaf activity", () => {
+    it("should allow an invisible leaf through flow navigation", () => {
       lesson1.isVisible = false;
-      expect(service.checkActivityProcess(lesson1)).toBe(false);
+      expect(service.checkActivityProcess(lesson1)).toBe(true);
     });
 
     it("should return false when attempt limit exceeded", () => {

--- a/test/helpers/mock-factories.ts
+++ b/test/helpers/mock-factories.ts
@@ -165,7 +165,11 @@ export interface MockProcessors {
 export function createMockProcessors(options: MockProcessorOptions = {}): MockProcessors {
   const measureProcessor = {
     measureRollupProcess: vi.fn().mockReturnValue(options.measureRollupResult ?? []),
-  } satisfies Pick<MeasureRollupProcessor, "measureRollupProcess">;
+    completionMeasureRollupProcess: vi.fn(),
+  } satisfies Pick<
+    MeasureRollupProcessor,
+    "measureRollupProcess" | "completionMeasureRollupProcess"
+  >;
 
   const objectiveProcessor = {
     objectiveRollupProcess: vi.fn(),

--- a/test/integration/SequencingForcedSequential_SCORM20043rdEdition.spec.ts
+++ b/test/integration/SequencingForcedSequential_SCORM20043rdEdition.spec.ts
@@ -493,22 +493,23 @@ wrappers.forEach((wrapper) => {
       expect(globalStatus?.satisfiedStatus).toBe(true);
     });
 
-    test("should prevent navigation when preConditionRule disables activity", async ({ page }) => {
+    test("should keep flow Continue valid while preConditionRule blocks direct choice", async ({
+      page,
+    }) => {
       await launchSequencedModule(page);
       await waitForModuleFrame(page);
 
       const continueButton = page.locator('button[data-directive="continue"]');
-      await expect(continueButton).toBeDisabled();
-
-      // Verify clicking a disabled button has no effect (via force click to bypass actionability)
-      await continueButton.click({ force: true });
-      await page.waitForTimeout(500);
-
-      const frameSrc = await getModuleFramePath(page);
-      expect(frameSrc).toContain("content=playing");
+      await expect(continueButton).toBeEnabled();
 
       const navResult = await getNavigationValidity(page, "continue");
-      expect(["false", "unknown"]).toContain(navResult);
+      expect(navResult).toBe("true");
+
+      // Continue is a valid request for any activity in this flow cluster. The
+      // next activity's precondition is evaluated after End Attempt transfers
+      // the current SCO's RTE status; direct choice remains locked meanwhile.
+      const choiceResult = await getNavigationValidity(page, "choice", "etuqiette_item");
+      expect(choiceResult).toBe("false");
     });
 
     /**

--- a/test/integration/SequencingPreOrPostTestRollup_SCORM20043rdEdition.spec.ts
+++ b/test/integration/SequencingPreOrPostTestRollup_SCORM20043rdEdition.spec.ts
@@ -368,9 +368,11 @@ wrappers.forEach((wrapper) => {
       await waitForScoContent(page, POSTTEST_ACTIVITY.key);
     };
 
-    const completeSequentialContent = async (page: any) => {
+    const completeSequentialContent = async (page: any, alreadyAtFirstContent = false) => {
       // Navigate to first content activity - course starts on pretest by default
-      await requestChoiceNavigation(page, CONTENT_ACTIVITIES[0].id);
+      if (!alreadyAtFirstContent) {
+        await requestChoiceNavigation(page, CONTENT_ACTIVITIES[0].id);
+      }
 
       for (let i = 0; i < CONTENT_ACTIVITIES.length; i++) {
         const { key } = CONTENT_ACTIVITIES[i];
@@ -493,6 +495,19 @@ wrappers.forEach((wrapper) => {
       const posttestValidity = await getNavigationValidity(page, "choice", POSTTEST_ACTIVITY.id);
       expect(["false", "unknown"]).toContain(pretestValidity);
       expect(["false", "unknown"]).toContain(posttestValidity);
+
+      // The successful mapped assessment remains authoritative if the learner exits from the
+      // incomplete content SCO that flow delivered next. A descendant rollup must not replace the
+      // read-mapped dummy wrapper's satisfied state with the content aggregate.
+      await requestContentNavigation(page, "exit");
+      const finalRootResult = await page.evaluate(() => {
+        const rootActivity = (window as any).API_1484_11.getSequencingState()?.rootActivity;
+        return {
+          completionStatus: rootActivity?.completionStatus || null,
+          successStatus: rootActivity?.successStatus || null,
+        };
+      });
+      expect(finalRootResult).toEqual({ completionStatus: "completed", successStatus: "passed" });
     });
 
     /**
@@ -725,6 +740,15 @@ wrappers.forEach((wrapper) => {
       );
       expect(assessmentObjective?.satisfiedStatus).toBe(true);
 
+      const rootResult = await page.evaluate(() => {
+        const rootActivity = (window as any).API_1484_11.getSequencingState()?.rootActivity;
+        return {
+          completionStatus: rootActivity?.completionStatus || null,
+          successStatus: rootActivity?.successStatus || null,
+        };
+      });
+      expect(rootResult).toEqual({ completionStatus: "completed", successStatus: "passed" });
+
       const pretestValidity = await getNavigationValidity(page, "choice", PRETEST_ACTIVITY.id);
       const posttestValidity = await getNavigationValidity(page, "choice", POSTTEST_ACTIVITY.id);
       expect(["false", "unknown"]).toContain(pretestValidity);
@@ -748,7 +772,13 @@ wrappers.forEach((wrapper) => {
       page,
     }) => {
       await launchSequencedModule(page);
-      await completeSequentialContent(page);
+      // Exercise the actual module's full-course branch: fail the pre-test first. The post-test's
+      // primary objective is then launch-seeded with that failed score through its read map.
+      await startPretest(page);
+      await completeAssessmentSCO(page, false);
+      await requestContentNavigation(page, "continue");
+      await waitForScoContent(page, CONTENT_ACTIVITIES[0].key);
+      await completeSequentialContent(page, true);
 
       // Query from global objective map in sequencing state
       const contentObjective = await getGlobalObjectiveStatus(
@@ -759,6 +789,26 @@ wrappers.forEach((wrapper) => {
 
       await startPosttest(page);
       await completeAssessmentSCO(page, true);
+
+      const posttestBeforeExit = await page.evaluate(() => {
+        const api = (window as any).API_1484_11;
+        const primaryObjective = api.cmi.objectives.childArray.find(
+          (objective: any) => objective.id === "assessment_satisfied",
+        );
+        return {
+          score: api.cmi.score.scaled,
+          objectiveScore: primaryObjective?.score?.scaled || null,
+          writtenElements: Array.from(api._runtimeSetCMIElements || []),
+          transferData: api._sequencingService.getCMIDataForTransfer(),
+        };
+      });
+      expect(posttestBeforeExit.score).toBe("1");
+      expect(Number(posttestBeforeExit.objectiveScore)).toBeLessThan(0.7);
+      expect(posttestBeforeExit.writtenElements).toContain("cmi.score.scaled");
+      expect(posttestBeforeExit.writtenElements).not.toContain("cmi.objectives.0.score.scaled");
+      expect(posttestBeforeExit.transferData.score_was_set).toBe(true);
+      expect(posttestBeforeExit.transferData.objectives[0].score_was_set).toBe(false);
+
       await requestContentNavigation(page, "exit");
 
       // Query from global objective map in sequencing state
@@ -767,6 +817,24 @@ wrappers.forEach((wrapper) => {
         "com.scorm.golfsamples.sequencing.preorposttestrollup.assessment_satisfied",
       );
       expect(assessmentObjective?.satisfiedStatus).toBe(true);
+
+      const rootResult = await page.evaluate(() => {
+        const rootActivity = (window as any).API_1484_11.getSequencingState()?.rootActivity;
+        const dummyActivity = rootActivity?.children?.find(
+          (activity: any) => activity.id === "dummy_item",
+        );
+        return {
+          completionStatus: rootActivity?.completionStatus || null,
+          successStatus: rootActivity?.successStatus || null,
+          dummySuccessStatus: dummyActivity?.successStatus || null,
+        };
+      });
+      expect(rootResult).toEqual({
+        completionStatus: "completed",
+        successStatus: "passed",
+        dummySuccessStatus: "passed",
+      });
+      expect(assessmentObjective?.normalizedMeasure).toBe(1);
     });
 
     /**

--- a/test/serialization/scorm2004_data_serializer.spec.ts
+++ b/test/serialization/scorm2004_data_serializer.spec.ts
@@ -4,8 +4,117 @@ import {
   DataSerializerContext,
   Scorm2004DataSerializer,
 } from "../../src/serialization/scorm2004_data_serializer";
+import { SequencingService } from "../../src/services/SequencingService";
 
 describe("Scorm2004DataSerializer", () => {
+  it("uses the course root only for terminate commit status", () => {
+    const context = {
+      getSettings: () => ({ autoPopulateCommitMetadata: false, dataCommitFormat: "json" }),
+      cmi: {
+        completion_status: "incomplete",
+        success_status: "unknown",
+        score: { getScoreObject: () => ({}) },
+        getCurrentTotalTime: () => "PT0S",
+      },
+      sequencingService: {
+        getSequencingState: () => ({
+          rootActivity: {
+            completionStatus: "completed",
+            successStatus: "passed",
+          },
+        }),
+      } as unknown as SequencingService,
+      renderCMIToJSONObject: () => ({
+        cmi: {
+          completion_status: "incomplete",
+          success_status: "unknown",
+        },
+      }),
+    } as unknown as DataSerializerContext;
+    const serializer = new Scorm2004DataSerializer(context);
+
+    const ordinaryCommit = serializer.renderCommitObject(false);
+    const terminateCommit = serializer.renderCommitObject(true);
+
+    expect(ordinaryCommit.completionStatus).toBe("incomplete");
+    expect(ordinaryCommit.successStatus).toBe("unknown");
+    expect(terminateCommit.completionStatus).toBe("completed");
+    expect(terminateCommit.successStatus).toBe("passed");
+    expect(terminateCommit.runtimeData.cmi).toMatchObject({
+      completion_status: "incomplete",
+      success_status: "unknown",
+    });
+  });
+
+  it("keeps an incomplete course root when the active SCO is complete", () => {
+    const context = {
+      getSettings: () => ({ autoPopulateCommitMetadata: false, dataCommitFormat: "json" }),
+      cmi: {
+        completion_status: "completed",
+        success_status: "passed",
+        score: { getScoreObject: () => ({ scaled: 1 }) },
+        getCurrentTotalTime: () => "PT0S",
+      },
+      sequencingService: {
+        getSequencingState: () => ({
+          rootActivity: {
+            completionStatus: "incomplete",
+            successStatus: "unknown",
+          },
+        }),
+      } as unknown as SequencingService,
+      renderCMIToJSONObject: () => ({
+        cmi: {
+          completion_status: "completed",
+          success_status: "passed",
+        },
+      }),
+    } as unknown as DataSerializerContext;
+
+    const commit = new Scorm2004DataSerializer(context).renderCommitObject(true);
+
+    expect(commit.completionStatus).toBe("incomplete");
+    expect(commit.successStatus).toBe("unknown");
+    expect(commit.runtimeData.cmi).toMatchObject({
+      completion_status: "completed",
+      success_status: "passed",
+    });
+  });
+
+  it("uses the rolled-up course score for a terminate commit", () => {
+    const context = {
+      getSettings: () => ({ autoPopulateCommitMetadata: false, dataCommitFormat: "json" }),
+      cmi: {
+        completion_status: "incomplete",
+        success_status: "unknown",
+        score: { getScoreObject: () => ({}) },
+        getCurrentTotalTime: () => "PT0S",
+      },
+      sequencingService: {
+        getSequencingState: () => ({
+          rootActivity: {
+            completionStatus: "completed",
+            successStatus: "passed",
+            objectiveMeasureStatus: true,
+            objectiveNormalizedMeasure: 1,
+            primaryObjective: null,
+          },
+        }),
+      } as unknown as SequencingService,
+      renderCMIToJSONObject: () => ({
+        cmi: {
+          completion_status: "incomplete",
+          success_status: "unknown",
+          score: { scaled: "", raw: "", min: "", max: "" },
+        },
+      }),
+    } as unknown as DataSerializerContext;
+    const serializer = new Scorm2004DataSerializer(context);
+
+    expect(serializer.renderCommitObject(false).score).toEqual({});
+    expect(serializer.renderCommitObject(true).score).toEqual({ scaled: 1 });
+  });
+
   it("commits the existing global objective map without ending the activity attempt", () => {
     const snapshot = {
       "gObj-SX11": {


### PR DESCRIPTION
# Pull Request

## Description

Fixes SCORM 2004 sequencing behavior that could advertise invalid navigation, skip reachable activities, or finish a sequenced course without the correct rolled-up completion, success, and measure state.

This was reproduced downstream with the ADL Golf sequencing packages, including `SequencingPostTestRollup4thEd_SCORM20044thEdition.zip`, where the learner could reach the first activity and quiz but could not navigate through the intervening activities.

## Related Issues

No linked issue; discovered through Nets LMS integration UAT.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test improvements

## Implementation Details

- Align navigation look-ahead with the actual sequencing traversal and termination paths so `adl.nav.request_valid` reflects executable Continue, Previous, and Choice requests.
- Transfer activity completion, success, objectives, and measures into sequencing state before rollup.
- Correct default and configured rollup evaluation, including objective-measure weights, minimum count/percentage rules, and asset-only activity trees.
- Preserve the sequencing and rollup fields required across serialization and restore.
- Add regressions for forced sequencing, pre/post test-out and full-course branches, navigation validity, RTE transfer, rollup rules, and state serialization.

## Testing Performed

- `npm run test:min`: 197 files, 6,927 tests passed.
- `npm run lint`: passed.
- Targeted Playwright sequencing coverage: Chromium and Firefox passed.
- Downstream public-share UAT through the normal Nets LMS upload, launch, navigation, commit, and learner-detail flow: all seven workflows across the six ADL Golf sequencing ZIPs passed.
- The original fourth-edition post-test package traversed all four content activities, reached the quiz, and persisted Completed/Passed with a 100% score.

## Checklist

- [x] This PR does not include changes to files under `dist/` (CI will build and commit `dist/` on the default branch)
- [x] I have read the Contribution Guidelines
- [x] The code follows the TypeScript style guide
- [x] Tests were added for the corrected behavior
- [x] `npm run test:min` passes
- [x] `npm run lint` passes; no automatic fixes were needed
- [x] The commit follows the Conventional Commits guidelines
- [ ] Documentation changes — N/A; this corrects internal sequencing behavior without changing the public API
- [ ] Local WebKit integration run — unavailable because the host browser dependencies are not installed; repository CI covers its configured Chromium and Firefox matrix

## Additional Context

Local `dist/` output was intentionally excluded in accordance with repository policy. CI should generate and commit distribution artifacts after merge to `master`.
