### PR TITLE
test(scorm2004): extend full-course sequencing timeout

### DIFF
--- a/test/integration/SequencingPreOrPostTestRollup_SCORM20043rdEdition.spec.ts
+++ b/test/integration/SequencingPreOrPostTestRollup_SCORM20043rdEdition.spec.ts
@@ -771,6 +771,7 @@ wrappers.forEach((wrapper) => {
     test("should allow full course completion via content and post-test per SCORM 2004 SN Book SB.2.4", async ({
       page,
     }) => {
+      test.setTimeout(120_000);
       await launchSequencedModule(page);
       // Exercise the actual module's full-course branch: fail the pre-test first. The post-test's
       // primary objective is then launch-seeded with that failed score through its read map.


### PR DESCRIPTION
## Summary

- give the expanded pre-test/content/post-test integration scenario a test-specific 120-second budget
- keep the repository-wide 60-second timeout unchanged for all other tests
- avoid changing sequencing or player behavior because the Firefox traces show normal quiz progress until Playwright closes the page

## Verification

- `npm run lint`
- `npm test` (197 files, 6,927 tests)
- Firefox targeted test with the original 60-second limit reproduced the merged CI failure
- Firefox targeted test with 120 seconds passed in 1.2 minutes
- Firefox Standard and ESM variants passed twice each with four concurrent workers (4/4)