### PR TITLE
fix(scorm2004): preserve sequenced activity state

### DIFF
--- a/src/Scorm2004API.ts
+++ b/src/Scorm2004API.ts
@@ -105,6 +105,7 @@ const NO_DEFAULT_2004_ELEMENTS: ReadonlySet<string> = new Set<string>([
   "cmi.interactions.N.learner_response",
   "cmi.interactions.N.description",
   "cmi.comments_from_learner.N.timestamp",
+  "adl.data.N.store",
 ]);
 
 /** Replace each numeric array-index segment with "N" so paths match the table. */
@@ -204,6 +205,7 @@ class Scorm2004API extends BaseAPI {
     const dataSerializerContext: DataSerializerContext = {
       getSettings: () => this.settings,
       cmi: this.cmi,
+      adl: this.adl,
       sequencingService: this._sequencingService,
       renderCMIToJSONObject: this.renderCMIToJSONObject.bind(this),
     };
@@ -253,8 +255,8 @@ class Scorm2004API extends BaseAPI {
     this._runtimeSetCMIElements.clear();
 
     this.cmi?.reset();
-    this.applyCurrentActivityLaunchData();
     this.adl?.reset();
+    this.applyCurrentActivityLaunchData();
   }
 
   /**
@@ -269,6 +271,7 @@ class Scorm2004API extends BaseAPI {
       return;
     }
 
+    this.adl.configureSharedDataMaps(currentActivity.sharedDataMaps);
     this.applyActivityLaunchData(currentActivity);
   }
 
@@ -280,6 +283,7 @@ class Scorm2004API extends BaseAPI {
    * @spec SCORM 2004 4th Ed. RTE 4.2.17, Table 4.2.17a - cmi.objectives is initialized before SCO access.
    */
   private applyDeliveredActivityLaunchData(activity: Activity): void {
+    this.adl.configureSharedDataMaps(activity.sharedDataMaps);
     // @spec SCORM 2004 4th Ed. RTE 3.1.6 - API Instance State Transition;
     // launch data is prepared before the SCO opens its communication session.
     if (!this.isNotInitialized()) {
@@ -601,6 +605,16 @@ class Scorm2004API extends BaseAPI {
     this._globalObjectiveManager.restoreGlobalObjectiveSnapshot(snapshot);
   }
 
+  /** Restore the LMS-persisted SCORM 2004 shared-data stores. */
+  restoreSharedDataSnapshot(snapshot: Record<string, string>): void {
+    this.adl.restoreSharedDataSnapshot(snapshot);
+  }
+
+  /** Capture all SCORM 2004 shared-data stores, including non-current mappings. */
+  captureSharedDataSnapshot(): Record<string, string> {
+    return this.adl.captureSharedDataSnapshot();
+  }
+
   /**
    * Compress state data (delegates to persistence class)
    * @param {string} data - Data to compress
@@ -655,6 +669,10 @@ class Scorm2004API extends BaseAPI {
       "LMS was already initialized!",
       "LMS is already finished!",
     );
+
+    if (result === global_constants.SCORM_TRUE) {
+      this.adl.initialize();
+    }
 
     if (result === global_constants.SCORM_TRUE && this._sequencingService) {
       this._sequencingService.initialize();
@@ -753,11 +771,20 @@ class Scorm2004API extends BaseAPI {
 
     if (result === global_constants.SCORM_TRUE && !wasAlreadyTerminated && !deliveryInProgress) {
       let navigationHandled = false;
+      let sequencingAttempted = false;
       let processedSequencingRequest: string | null = null;
 
       if (this._sequencingService) {
         try {
           if (requestToProcess) {
+            // A prepared request proves that the internal engine was available
+            // and accepted the request for completion. If preparation was not
+            // possible, only invoke the compatibility path when the internal
+            // engine itself is unavailable; an available engine rejecting a
+            // request must not duplicate it through legacy listeners.
+            const sequencingAvailable =
+              this._sequencingService.getSequencingState().isInitialized === true;
+            sequencingAttempted = sequencingAvailable;
             navigationHandled = preparedNavigation
               ? this._sequencingService.completeNavigationRequest(preparedNavigation)
               : this._sequencingService.processNavigationRequest(
@@ -768,16 +795,12 @@ class Scorm2004API extends BaseAPI {
             processedSequencingRequest = requestToProcess;
           }
         } catch (error) {
-          this.apiLog(
-            "lmsFinish",
-            `Sequencing navigation failed, falling back to event-based navigation: ${error}`,
-            LogLevelEnum.WARN,
-          );
+          this.apiLog("lmsFinish", `Sequencing navigation failed: ${error}`, LogLevelEnum.WARN);
           navigationHandled = false;
         }
       }
 
-      if (!navigationHandled) {
+      if (!navigationHandled && !sequencingAttempted) {
         if (pendingNavRequest !== "_none_") {
           const navActions: { [key: string]: string } = {
             continue: "SequenceNext",
@@ -1203,6 +1226,7 @@ class Scorm2004API extends BaseAPI {
   protected override checkUninitializedGet(CMIElement: string, returnValue: any): void {
     if (returnValue !== "") return;
     if (this._setCMIElements.has(CMIElement)) return;
+    if (this.adl.isConfiguredSharedDataElement(CMIElement)) return;
     if (!NO_DEFAULT_2004_ELEMENTS.has(normalizeCMIIndices(CMIElement))) return;
 
     this.throwSCORMError(

--- a/src/cmi/scorm2004/adl.ts
+++ b/src/cmi/scorm2004/adl.ts
@@ -3,6 +3,7 @@ import { CMIArray } from "../common/array";
 import { Scorm2004ValidationError } from "../../exceptions/scorm2004_exceptions";
 import { check2004ValidFormat } from "./validation";
 import { Sequencing } from "./sequencing/sequencing";
+import type { SharedDataMapInfo } from "./sequencing/activity";
 import {
   NAVBoolean,
   scorm2004_constants,
@@ -26,6 +27,7 @@ export class ADL extends BaseCMI {
   public nav: ADLNav;
   public data = new ADLData();
   private _sequencing: Sequencing | null = null;
+  private _sharedDataStores: Record<string, string> = Object.create(null);
 
   /**
    * Called when the API has been initialized after the CMI has been created
@@ -33,6 +35,7 @@ export class ADL extends BaseCMI {
   override initialize() {
     super.initialize();
     this.nav?.initialize();
+    this.data?.initialize();
   }
 
   /**
@@ -41,6 +44,69 @@ export class ADL extends BaseCMI {
   reset() {
     this._initialized = false;
     this.nav?.reset();
+    this.data?.reset();
+  }
+
+  /**
+   * Configure the adl.data view for the activity being delivered.
+   *
+   * ADL data stores are keyed by the manifest targetID, while the RTE exposes
+   * only the mappings for the currently delivered activity as adl.data.n.
+   * Rebuilding that view is therefore safe: values live in this ADL-owned
+   * backing map and survive SCO reset/navigation.
+   */
+  configureSharedDataMaps(maps: SharedDataMapInfo[] = []): void {
+    this.captureVisibleSharedData();
+    this.data.configure(maps, this._sharedDataStores);
+  }
+
+  captureSharedDataSnapshot(): Record<string, string> {
+    this.captureVisibleSharedData();
+    return { ...this._sharedDataStores };
+  }
+
+  /** Capture only initialized stores this activity is allowed to write. */
+  captureWritableSharedDataSnapshot(): Record<string, string> {
+    this.captureVisibleSharedData();
+    const writableStores: Record<string, string> = {};
+    for (const child of this.data.childArray) {
+      const dataObject = child as ADLDataObject;
+      if (dataObject.id && dataObject.storeIsSet && dataObject.writeSharedData) {
+        writableStores[dataObject.id] = dataObject.storeValue;
+      }
+    }
+    return writableStores;
+  }
+
+  restoreSharedDataSnapshot(snapshot: Record<string, string> | null | undefined): void {
+    if (!snapshot || typeof snapshot !== "object") {
+      return;
+    }
+    for (const targetID of Object.keys(this._sharedDataStores)) {
+      delete this._sharedDataStores[targetID];
+    }
+    for (const [targetID, store] of Object.entries(snapshot)) {
+      if (typeof targetID === "string" && typeof store === "string") {
+        this._sharedDataStores[targetID] = store;
+      }
+    }
+    this.data.refreshStores(this._sharedDataStores);
+  }
+
+  isConfiguredSharedDataElement(CMIElement: string): boolean {
+    return this.data.isConfiguredElement(CMIElement);
+  }
+
+  private captureVisibleSharedData(): void {
+    for (const child of this.data.childArray) {
+      const dataObject = child as ADLDataObject;
+      // Presence in the backing record is the initialized bit.  In particular,
+      // do not turn a configured-but-never-written bucket into an initialized
+      // empty string while rotating the activity's mapped view.
+      if (dataObject.id && dataObject.storeIsSet) {
+        this._sharedDataStores[dataObject.id] = dataObject.storeValue;
+      }
+    }
   }
 
   /**
@@ -127,7 +193,9 @@ export class ADLNav extends BaseCMI {
    */
   override initialize() {
     super.initialize();
-    this.request_valid?.initialize();
+    if (typeof this.request_valid?.initialize === "function") {
+      this.request_valid.initialize();
+    }
   }
 
   /**
@@ -194,6 +262,60 @@ export class ADLData extends CMIArray {
       errorClass: Scorm2004ValidationError,
     });
   }
+
+  override initialize(): void {
+    super.initialize();
+    for (const child of this.childArray) {
+      child.initialize();
+    }
+  }
+
+  override reset(wipe: boolean = false): void {
+    this._initialized = false;
+    if (wipe) {
+      this.childArray = [];
+      return;
+    }
+    for (const child of this.childArray) {
+      (child as ADLDataObject).deinitialize();
+    }
+  }
+
+  configure(maps: SharedDataMapInfo[], stores: Record<string, string>): void {
+    this.childArray = maps.map((map) => {
+      const child = new ADLDataObject();
+      const storeIsSet = Object.prototype.hasOwnProperty.call(stores, map.targetID);
+      child.configure(
+        map.targetID,
+        storeIsSet ? stores[map.targetID]! : "",
+        map.readSharedData,
+        map.writeSharedData,
+        storeIsSet,
+        (value) => {
+          stores[map.targetID] = value;
+        },
+      );
+      if (this.initialized) {
+        child.initialize();
+      }
+      return child;
+    });
+  }
+
+  refreshStores(stores: Record<string, string>): void {
+    for (const child of this.childArray) {
+      const dataObject = child as ADLDataObject;
+      const storeIsSet = Object.prototype.hasOwnProperty.call(stores, dataObject.id);
+      dataObject.refreshStore(storeIsSet ? stores[dataObject.id]! : "", storeIsSet);
+    }
+  }
+
+  isConfiguredElement(CMIElement: string): boolean {
+    const match = /^adl\.data\.(\d+)\.store$/.exec(CMIElement);
+    if (!match) return false;
+    const index = Number(match[1]);
+    return Number.isInteger(index) && index >= 0 && index < this.childArray.length;
+  }
 }
 
 /**
@@ -204,9 +326,14 @@ export class ADLDataObject extends BaseCMI {
   private _store = "";
   private _idIsSet = false;
   private _storeIsSet = false;
+  private _readSharedData = true;
+  private _writeSharedData = true;
+  private _onStoreChange: ((value: string) => void) | null = null;
+  private readonly _allowStoreWithoutId: boolean;
 
-  constructor() {
+  constructor(allowStoreWithoutId: boolean = false) {
     super("adl.data.n");
+    this._allowStoreWithoutId = allowStoreWithoutId;
   }
 
   /**
@@ -216,6 +343,33 @@ export class ADLDataObject extends BaseCMI {
     this._initialized = false;
     this._idIsSet = false;
     this._storeIsSet = false;
+  }
+
+  configure(
+    id: string,
+    store: string | undefined,
+    readSharedData: boolean,
+    writeSharedData: boolean,
+    storeIsSet: boolean,
+    onStoreChange: (value: string) => void,
+  ): void {
+    this._id = id;
+    this._store = store ?? "";
+    this._idIsSet = true;
+    this._storeIsSet = storeIsSet;
+    this._readSharedData = readSharedData;
+    this._writeSharedData = writeSharedData;
+    this._onStoreChange = onStoreChange;
+  }
+
+  refreshStore(store: string, storeIsSet: boolean): void {
+    this._store = store;
+    this._storeIsSet = storeIsSet;
+  }
+
+  /** End the SCO session without discarding this LMS-configured bucket. */
+  deinitialize(): void {
+    this._initialized = false;
   }
 
   /**
@@ -251,6 +405,12 @@ export class ADLDataObject extends BaseCMI {
    * @return {string}
    */
   get store(): string {
+    if (this.initialized && !this._readSharedData) {
+      throw new Scorm2004ValidationError(
+        this._cmi_element + ".store",
+        scorm2004_errors.WRITE_ONLY_ELEMENT as number,
+      );
+    }
     // REQ-ADL-020: GetValue on uninitialized store returns error 403
     if (this.initialized && !this._storeIsSet) {
       throw new Scorm2004ValidationError(
@@ -268,8 +428,14 @@ export class ADLDataObject extends BaseCMI {
    * @param {string} store
    */
   set store(store: string) {
+    if (this.initialized && !this._writeSharedData) {
+      throw new Scorm2004ValidationError(
+        this._cmi_element + ".store",
+        scorm2004_errors.READ_ONLY_ELEMENT as number,
+      );
+    }
     // REQ-ADL-025: Dependency check - id must be set before store
-    if (this.initialized && !this._idIsSet) {
+    if (this.initialized && !this._allowStoreWithoutId && !this._idIsSet) {
       throw new Scorm2004ValidationError(
         this._cmi_element + ".store",
         scorm2004_errors.DEPENDENCY_NOT_ESTABLISHED as number,
@@ -277,11 +443,32 @@ export class ADLDataObject extends BaseCMI {
     }
     // REQ-ADL-017: store SPM is 64000 characters (was incorrectly 4000)
     if (
-      check2004ValidFormat(this._cmi_element + ".store", store, scorm2004_regex.CMIString64000)
+      check2004ValidFormat(
+        this._cmi_element + ".store",
+        store,
+        scorm2004_regex.CMIString64000,
+        true,
+      )
     ) {
       this._store = store;
       this._storeIsSet = true;
+      this._onStoreChange?.(store);
     }
+  }
+
+  /** Internal value access used while rotating the mapped view. */
+  get storeValue(): string {
+    return this._store;
+  }
+
+  /** Whether the LMS has initialized this mapped store. */
+  get storeIsSet(): boolean {
+    return this._storeIsSet;
+  }
+
+  /** Whether the current activity may write this shared-data bucket. */
+  get writeSharedData(): boolean {
+    return this._writeSharedData;
   }
 
   /**
@@ -645,9 +832,7 @@ export class ADLNavRequestValid extends BaseCMI {
         scorm2004_errors.READ_ONLY_ELEMENT as number,
       );
     }
-    if (
-      check2004ValidFormat(this._cmi_element + ".exit", _exit, scorm2004_regex.NAVBoolean)
-    ) {
+    if (check2004ValidFormat(this._cmi_element + ".exit", _exit, scorm2004_regex.NAVBoolean)) {
       this._exit = _exit;
     }
   }
@@ -724,7 +909,11 @@ export class ADLNavRequestValid extends BaseCMI {
       );
     }
     if (
-      check2004ValidFormat(this._cmi_element + ".abandonAll", _abandonAll, scorm2004_regex.NAVBoolean)
+      check2004ValidFormat(
+        this._cmi_element + ".abandonAll",
+        _abandonAll,
+        scorm2004_regex.NAVBoolean,
+      )
     ) {
       this._abandonAll = _abandonAll;
     }
@@ -750,7 +939,11 @@ export class ADLNavRequestValid extends BaseCMI {
       );
     }
     if (
-      check2004ValidFormat(this._cmi_element + ".suspendAll", _suspendAll, scorm2004_regex.NAVBoolean)
+      check2004ValidFormat(
+        this._cmi_element + ".suspendAll",
+        _suspendAll,
+        scorm2004_regex.NAVBoolean,
+      )
     ) {
       this._suspendAll = _suspendAll;
     }

--- a/src/cmi/scorm2004/sequencing/activity.ts
+++ b/src/cmi/scorm2004/sequencing/activity.ts
@@ -33,6 +33,12 @@ export interface ObjectiveMapInfo {
   updateAttemptData?: boolean;
 }
 
+export interface SharedDataMapInfo {
+  targetID: string;
+  readSharedData: boolean;
+  writeSharedData: boolean;
+}
+
 export interface ActivityObjectiveOptions {
   description?: string | null;
   satisfiedByMeasure?: boolean;
@@ -725,6 +731,7 @@ export class Activity extends BaseCMI {
   private _isAvailable: boolean = true;
   private _hideLmsUi: HideLmsUiItem[] = [];
   private _auxiliaryResources: AuxiliaryResource[] = [];
+  private _sharedDataMaps: SharedDataMapInfo[] = [];
   private _attemptLimit: number | null = null;
   private _attemptAbsoluteDurationLimit: string | null = null;
   private _activityAbsoluteDurationLimit: string | null = null;
@@ -750,12 +757,6 @@ export class Activity extends BaseCMI {
     requiredForIncomplete: "always",
     measureSatisfactionIfActive: true,
   };
-  // Individual rollup consideration properties for this activity (RB.1.4.2)
-  // These determine when THIS activity is included in parent rollup calculations
-  private _requiredForSatisfied: RollupConsiderationRequirement = "always";
-  private _requiredForNotSatisfied: RollupConsiderationRequirement = "always";
-  private _requiredForCompleted: RollupConsiderationRequirement = "always";
-  private _requiredForIncomplete: RollupConsiderationRequirement = "always";
   private _wasSkipped: boolean = false;
   private _attemptProgressStatus: boolean = false;
   private _wasAutoCompleted: boolean = false;
@@ -1869,35 +1870,35 @@ export class Activity extends BaseCMI {
    * These control when THIS activity is included in parent rollup
    */
   get requiredForSatisfied(): RollupConsiderationRequirement {
-    return this._requiredForSatisfied;
+    return this._rollupConsiderations.requiredForSatisfied;
   }
 
   set requiredForSatisfied(value: RollupConsiderationRequirement) {
-    this._requiredForSatisfied = value;
+    this._rollupConsiderations.requiredForSatisfied = value;
   }
 
   get requiredForNotSatisfied(): RollupConsiderationRequirement {
-    return this._requiredForNotSatisfied;
+    return this._rollupConsiderations.requiredForNotSatisfied;
   }
 
   set requiredForNotSatisfied(value: RollupConsiderationRequirement) {
-    this._requiredForNotSatisfied = value;
+    this._rollupConsiderations.requiredForNotSatisfied = value;
   }
 
   get requiredForCompleted(): RollupConsiderationRequirement {
-    return this._requiredForCompleted;
+    return this._rollupConsiderations.requiredForCompleted;
   }
 
   set requiredForCompleted(value: RollupConsiderationRequirement) {
-    this._requiredForCompleted = value;
+    this._rollupConsiderations.requiredForCompleted = value;
   }
 
   get requiredForIncomplete(): RollupConsiderationRequirement {
-    return this._requiredForIncomplete;
+    return this._rollupConsiderations.requiredForIncomplete;
   }
 
   set requiredForIncomplete(value: RollupConsiderationRequirement) {
-    this._requiredForIncomplete = value;
+    this._rollupConsiderations.requiredForIncomplete = value;
   }
 
   get wasSkipped(): boolean {
@@ -2469,6 +2470,7 @@ export class Activity extends BaseCMI {
       activityAttemptActive: this._activityAttemptActive,
       isHiddenFromChoice: this._isHiddenFromChoice,
       isAvailable: this._isAvailable,
+      sharedDataMaps: this.sharedDataMaps,
       rollupConsiderations: { ...this._rollupConsiderations },
       wasSkipped: this._wasSkipped,
       attemptProgressStatus: this._attemptProgressStatus,
@@ -2697,6 +2699,7 @@ export class Activity extends BaseCMI {
       attemptCompletionAmountStatus: this._attemptCompletionAmountStatus,
       hideLmsUi: [...this._hideLmsUi],
       auxiliaryResources: this._auxiliaryResources.map((resource) => ({ ...resource })),
+      sharedDataMaps: this.sharedDataMaps,
       children: this._children.map((child) => child.toJSON()),
     };
     this.jsonString = false;
@@ -2705,6 +2708,21 @@ export class Activity extends BaseCMI {
 
   get auxiliaryResources(): AuxiliaryResource[] {
     return this._auxiliaryResources.map((resource) => ({ ...resource }));
+  }
+
+  /** SCORM 2004 shared-data bucket mappings for this activity. */
+  get sharedDataMaps(): SharedDataMapInfo[] {
+    return this._sharedDataMaps.map((map) => ({ ...map }));
+  }
+
+  set sharedDataMaps(maps: SharedDataMapInfo[]) {
+    this._sharedDataMaps = (maps || [])
+      .filter((map) => map && typeof map.targetID === "string" && map.targetID.length > 0)
+      .map((map) => ({
+        targetID: map.targetID,
+        readSharedData: map.readSharedData,
+        writeSharedData: map.writeSharedData,
+      }));
   }
 
   set auxiliaryResources(resources: AuxiliaryResource[]) {

--- a/src/cmi/scorm2004/sequencing/handlers/delivery_handler.ts
+++ b/src/cmi/scorm2004/sequencing/handlers/delivery_handler.ts
@@ -241,6 +241,7 @@ export class DeliveryHandler {
       // Step 3: Process activity path and initialize tracking data (DB.2.2)
       // Get the full path from root to delivered activity
       const activityPath = this.getActivityPath(activity, true);
+      const newAttemptActivities: Activity[] = [];
 
       // Process each activity in the path (root to leaf)
       for (const pathActivity of activityPath) {
@@ -254,6 +255,7 @@ export class DeliveryHandler {
             // the Objective and Attempt Progress Information scoped to this attempt.
             pathActivity.incrementAttemptCount();
             pathActivity.initializeTrackingForNewAttempt();
+            newAttemptActivities.push(pathActivity);
             pathActivity.objectiveInfoAvailableInCurrentParentAttempt = true;
             pathActivity.progressInfoAvailableInCurrentParentAttempt = true;
 
@@ -263,7 +265,12 @@ export class DeliveryHandler {
             // @spec SCORM 2004 SN 4th Ed. SM.1 and TM.2
             for (const child of pathActivity.children) {
               if (pathActivity.sequencingControls.useCurrentAttemptObjectiveInfo) {
-                child.objectiveInfoAvailableInCurrentParentAttempt = false;
+                // A read map is evaluated from the shared global objective regardless of the
+                // child's prior local attempt. Keep known mapped objective information available
+                // to sequencing and rollup during the new parent attempt.
+                // @spec SCORM 2004 3rd Ed. Impact Summary 1.5-8
+                child.objectiveInfoAvailableInCurrentParentAttempt =
+                  this.hasKnownReadMappedObjective(child);
               }
               if (pathActivity.sequencingControls.useCurrentAttemptProgressInfo) {
                 child.progressInfoAvailableInCurrentParentAttempt = false;
@@ -280,6 +287,17 @@ export class DeliveryHandler {
             pathActivity.attemptCount <= 1,
           );
         }
+      }
+
+      // The global-objective read phase runs before delivery so prerequisites can be checked.
+      // New-attempt initialization above intentionally clears attempt-scoped local objectives,
+      // so restore each newly active activity's read maps before navigation validity is computed.
+      // @spec SCORM 2004 SN 4th Ed. DB.2 and 3.10.3 Objective Map read timing
+      for (const pathActivity of newAttemptActivities) {
+        this.rollupProcess?.syncActivityObjectivesFromGlobals(
+          pathActivity,
+          this.globalObjectiveMap,
+        );
       }
 
       // Step 4: Set the activity as current
@@ -305,6 +323,25 @@ export class DeliveryHandler {
       // Clear delivery in progress flag
       this._deliveryInProgress = false;
     }
+  }
+
+  private hasKnownReadMappedObjective(activity: Activity): boolean {
+    const primaryObjective = activity.primaryObjective;
+    if (!primaryObjective) {
+      return false;
+    }
+
+    return primaryObjective.mapInfo.some((mapInfo) => {
+      const targetId = mapInfo.targetObjectiveID || primaryObjective.id;
+      const globalObjective = this.globalObjectiveMap.get(targetId);
+
+      return (
+        (mapInfo.readSatisfiedStatus !== false &&
+          globalObjective?.satisfiedStatusKnown === true) ||
+        (mapInfo.readNormalizedMeasure !== false &&
+          globalObjective?.normalizedMeasureKnown === true)
+      );
+    });
   }
 
   /**

--- a/src/cmi/scorm2004/sequencing/handlers/rte_data_transfer.ts
+++ b/src/cmi/scorm2004/sequencing/handlers/rte_data_transfer.ts
@@ -7,6 +7,7 @@ import { evaluateCompletionStatusFromThreshold } from "../../completion_status_e
  */
 export interface CMIDataForTransfer {
   completion_status?: string;
+  completion_status_was_set?: boolean;
   success_status?: string;
   success_status_was_set?: boolean;
   score_was_set?: boolean;
@@ -315,6 +316,12 @@ export class RteDataTransferService {
       let hasCompletionStatus = false;
       let hasProgressMeasure = false;
 
+      const topLevelCompletionStatus = validateCompletionStatus(cmiData.completion_status);
+      const topLevelPrimaryCompletionWasSet =
+        cmiData.completion_status_was_set === true ||
+        (cmiData.completion_status_was_set === undefined &&
+          topLevelCompletionStatus !== null &&
+          topLevelCompletionStatus !== CompletionStatus.UNKNOWN);
       const topLevelSuccessStatus = validateSuccessStatus(cmiData.success_status);
       const topLevelPrimarySuccessWasSet =
         cmiData.success_status_was_set === true ||
@@ -367,19 +374,24 @@ export class RteDataTransferService {
           activityObjective.initializeUnknownCompletionStatusFromCMI();
           hasCompletionStatus = true;
         }
-      } else if (validatedObjCompletionStatus !== null) {
+      } else if (
+        validatedObjCompletionStatus !== null &&
+        (cmiObjective.completion_status_was_set !== false ||
+          !isPrimaryObjective ||
+          !topLevelPrimaryCompletionWasSet)
+      ) {
         // @spec SCORM 2004 4th Ed. RTE 4.2.17 / SN 3.10.3 - an objective
         // completion status changed to unknown removes a previously known local
         // status; an untouched default unknown does not create a mapped write.
+        // A launch-seeded primary objective row likewise cannot replace a later
+        // content write to the top-level primary completion status.
         activityObjective.completionStatus = validatedObjCompletionStatus;
         hasCompletionStatus = true;
       }
 
       // Transfer score (with normalization)
       const objectiveScoreMayOverridePrimary =
-        cmiObjective.score_was_set !== false ||
-        !isPrimaryObjective ||
-        !topLevelPrimaryScoreWasSet;
+        cmiObjective.score_was_set !== false || !isPrimaryObjective || !topLevelPrimaryScoreWasSet;
       if (cmiObjective.score && objectiveScoreMayOverridePrimary) {
         // @spec SCORM 2004 4th Ed. ADLSEQ objectives extension - raw/min/max
         // score write maps use the RTE objective score values, independent of scaled score.

--- a/src/cmi/scorm2004/sequencing/objectives/global_objective_synchronizer.ts
+++ b/src/cmi/scorm2004/sequencing/objectives/global_objective_synchronizer.ts
@@ -371,6 +371,28 @@ export class GlobalObjectiveSynchronizer {
   }
 
   /**
+   * Read mapped global state into a newly initialized activity attempt.
+   *
+   * A read/write map normally suppresses reads while its activity is active so an in-progress
+   * attempt remains the source of the next write. During DB.2 delivery, however, the local
+   * attempt has just been initialized and must receive its mapped global state before content
+   * and sequencing inspect it.
+   *
+   * @spec SCORM 2004 SN 4th Ed. DB.2 and 3.10.3 Objective Map read timing
+   */
+  public syncGlobalObjectivesDeliveryReadPhase(
+    activity: Activity,
+    globalObjectives: Map<string, GlobalObjective>,
+  ): boolean {
+    return this.syncGlobalObjectivesReadPhaseInternal(
+      activity,
+      globalObjectives,
+      undefined,
+      true,
+    );
+  }
+
+  /**
    * Read only objective fields freshly written by a terminating descendant.
    *
    * Active write-mapped objectives normally suppress reads so a new attempt cannot revive its
@@ -391,6 +413,7 @@ export class GlobalObjectiveSynchronizer {
     activity: Activity,
     globalObjectives: Map<string, GlobalObjective>,
     writeTargets?: GlobalObjectiveWriteTargets,
+    allowActiveWriteMappedRead = false,
   ): boolean {
     const beforeStatus = activity.captureRollupStatus();
     const beforeObjectiveSatisfiedStatusKnown = activity.objectiveSatisfiedStatusKnown;
@@ -424,7 +447,13 @@ export class GlobalObjectiveSynchronizer {
                 allowSatisfiedStatus: freshlyWroteSatisfiedStatus,
                 allowNormalizedMeasure: freshlyWroteNormalizedMeasure,
               }
-            : undefined,
+            : allowActiveWriteMappedRead
+              ? {
+                  restrictToFreshWrites: false,
+                  allowSatisfiedStatus: true,
+                  allowNormalizedMeasure: true,
+                }
+              : undefined,
         );
         this.applyGlobalObjectiveReadState(objective, readState);
 

--- a/src/cmi/scorm2004/sequencing/overall_sequencing_process.ts
+++ b/src/cmi/scorm2004/sequencing/overall_sequencing_process.ts
@@ -334,6 +334,23 @@ export class OverallSequencingProcess {
         }
       }
 
+      // EXIT_ALL reached through an exit/post-condition cascade returns the EXIT
+      // sequencing request after it has already ended every activity attempt and
+      // cleared the current activity. Treat that pair as a terminal sequencing
+      // session instead of trying to process EXIT again without a current activity.
+      if (
+        termResult.terminationRequest === SequencingRequestType.EXIT_ALL &&
+        termResult.sequencingRequest === SequencingRequestType.EXIT
+      ) {
+        navResult.sequencingRequest = null;
+        return {
+          navigationRequest,
+          navResult,
+          deliveryRequest: null,
+          sessionEndReason: "exit_all",
+        };
+      }
+
       // If this is a termination-only request (no sequencing request), return success
       if (!navResult.sequencingRequest) {
         const sessionEndReason =
@@ -372,13 +389,15 @@ export class OverallSequencingProcess {
       return prepared.deliveryRequest;
     }
 
+    if (prepared.sessionEndReason) {
+      this.fireEvent("onSequencingSessionEnd", {
+        reason: prepared.sessionEndReason,
+        navigationRequest,
+      });
+      return new DeliveryRequest(true, null);
+    }
+
     if (!navResult.sequencingRequest) {
-      if (prepared.sessionEndReason) {
-        this.fireEvent("onSequencingSessionEnd", {
-          reason: prepared.sessionEndReason,
-          navigationRequest,
-        });
-      }
       return new DeliveryRequest(true, null);
     }
 

--- a/src/cmi/scorm2004/sequencing/rollup_process.ts
+++ b/src/cmi/scorm2004/sequencing/rollup_process.ts
@@ -271,6 +271,25 @@ export class RollupProcess {
   }
 
   /**
+   * Restore an activity's read-mapped objective state after new-attempt initialization.
+   *
+   * DB.2 initializes attempt-scoped local objectives, while objective maps remain available
+   * across activities. Reapply the read phase before sequencing rules and navigation validity
+   * inspect the delivered attempt.
+   *
+   * @spec SCORM 2004 SN 4th Ed. DB.2 and 3.10.3 Objective Map read timing
+   */
+  public syncActivityObjectivesFromGlobals(
+    activity: Activity,
+    globalObjectives: Map<string, GlobalObjective>,
+  ): boolean {
+    return this.globalObjectiveSynchronizer.syncGlobalObjectivesDeliveryReadPhase(
+      activity,
+      globalObjectives,
+    );
+  }
+
+  /**
    * Apply a terminating descendant's fresh objective writes to an active ancestor.
    *
    * @spec SCORM 2004 SN 4th Ed. SM.7 Objective Map write timing

--- a/src/configuration/activity_tree_builder.ts
+++ b/src/configuration/activity_tree_builder.ts
@@ -232,6 +232,14 @@ export class ActivityTreeBuilder {
       }
     }
 
+    if (activitySettings.sharedDataMaps) {
+      activity.sharedDataMaps = activitySettings.sharedDataMaps.map((map) => ({
+        targetID: map.targetID,
+        readSharedData: map.readSharedData ?? true,
+        writeSharedData: map.writeSharedData ?? false,
+      }));
+    }
+
     // Create child activities
     if (activitySettings.children) {
       for (const childSettings of activitySettings.children) {

--- a/src/handlers/scorm2004/cmi_handler.ts
+++ b/src/handlers/scorm2004/cmi_handler.ts
@@ -81,7 +81,7 @@ export class Scorm2004CMIHandler {
       // SCOs should only access indices < _count. However, we intentionally
       // allow dynamic creation for backward compatibility with content that
       // creates adl.data elements on-the-fly.
-      return new ADLDataObject();
+      return new ADLDataObject(true);
     }
 
     return null;

--- a/src/persistence/sequencing_state_persistence.ts
+++ b/src/persistence/sequencing_state_persistence.ts
@@ -211,6 +211,10 @@ export class SequencingStatePersistence {
         request: this.context.adl.nav.request,
         request_valid: this.context.adl.nav.request_valid,
       },
+      sharedData:
+        typeof this.context.adl.captureSharedDataSnapshot === "function"
+          ? this.context.adl.captureSharedDataSnapshot()
+          : {},
       contentDelivered: false,
     };
 
@@ -332,6 +336,23 @@ export class SequencingStatePersistence {
       }
 
       // Restore ADL nav state
+      if (
+        state.sharedData &&
+        typeof state.sharedData === "object" &&
+        typeof this.context.adl.restoreSharedDataSnapshot === "function"
+      ) {
+        this.context.adl.restoreSharedDataSnapshot(state.sharedData);
+      }
+
+      // Restoring the sequencing tree changes the activity whose ADL data view
+      // is exposed. Rebind it before the host can initialize the restored SCO;
+      // configureSharedDataMaps also preserves the initialized-vs-missing bit
+      // from the restored backing snapshot.
+      const restoredActivity = this.context.sequencing.getCurrentActivity();
+      if (restoredActivity && typeof this.context.adl.configureSharedDataMaps === "function") {
+        this.context.adl.configureSharedDataMaps(restoredActivity.sharedDataMaps);
+      }
+
       if (state.adlNavState) {
         this.context.adl.nav.request = state.adlNavState.request || "_none_";
         this.context.adl.nav.request_valid = state.adlNavState.request_valid || {};

--- a/src/serialization/scorm2004_data_serializer.ts
+++ b/src/serialization/scorm2004_data_serializer.ts
@@ -5,6 +5,7 @@ import { CompletionStatus, SuccessStatus } from "../constants/enums";
 import { scorm2004_regex } from "../constants/regex";
 import { SequencingService } from "../services/SequencingService";
 import { GlobalObjectiveManager } from "../objectives/global_objective_manager";
+import { ADL } from "../cmi/scorm2004/adl";
 
 /**
  * Render CMI to JSON function type
@@ -19,6 +20,7 @@ export type RenderCMIToJSONFn = () => StringKeyMap;
 export interface DataSerializerContext {
   getSettings: () => Settings;
   cmi: CMI;
+  adl?: ADL;
   sequencingService: SequencingService | null;
   renderCMIToJSONObject: RenderCMIToJSONFn;
 }
@@ -70,7 +72,37 @@ export class Scorm2004DataSerializer {
     terminateCommit: boolean,
     includeTotalTime: boolean = false,
   ): StringKeyMap | Array<any> {
+    const cmiExport = this.renderCMIExport(terminateCommit, includeTotalTime);
+    const sharedData = this.captureSharedData();
+
+    const flattened: StringKeyMap = flatten(cmiExport);
+    switch (this.context.getSettings().dataCommitFormat) {
+      case "flattened":
+        return flattened;
+      case "params":
+        return Object.entries(flattened).map(([item, value]) => `${item}=${value}`);
+      case "json":
+      default:
+        // Compact SCORM 2004 commits are the payload itself (rather than a
+        // runtimeData wrapper), so preserve sharedData at its top level.
+        if (sharedData) {
+          cmiExport.sharedData = sharedData;
+        }
+        return cmiExport;
+    }
+  }
+
+  /** Render the runtime CMI envelope without compact-commit metadata. */
+  private renderCMIExport(terminateCommit: boolean, includeTotalTime: boolean): StringKeyMap {
     const cmiExport: StringKeyMap = this.context.renderCMIToJSONObject();
+    // The structured commit's runtimeData includes the active CMI model and the currently mapped
+    // SCORM 2004 ADL data buckets. Navigation state belongs to sequencing persistence, not the
+    // per-SCO runtime envelope.
+    if (this.context.adl && this.context.adl.data._count > 0) {
+      cmiExport.adl = {
+        data: JSON.parse(JSON.stringify(this.context.adl.data)),
+      };
+    }
 
     if (terminateCommit || includeTotalTime) {
       // Add total_time to the exported cmi object
@@ -79,18 +111,18 @@ export class Scorm2004DataSerializer {
       // Remove total_time from export when not terminating
       delete (cmiExport.cmi as StringKeyMap).total_time;
     }
+    return cmiExport;
+  }
 
-    const flattened: StringKeyMap = flatten(cmiExport);
-    const settings = this.context.getSettings();
-    switch (settings.dataCommitFormat) {
-      case "flattened":
-        return flattened;
-      case "params":
-        return Object.entries(flattened).map(([item, value]) => `${item}=${value}`);
-      case "json":
-      default:
-        return cmiExport;
+  private captureSharedData(): Record<string, string> | null {
+    if (
+      !this.context.adl ||
+      typeof this.context.adl.captureWritableSharedDataSnapshot !== "function"
+    ) {
+      return null;
     }
+    const sharedData = this.context.adl.captureWritableSharedDataSnapshot();
+    return Object.keys(sharedData).length > 0 ? sharedData : null;
   }
 
   /**
@@ -101,6 +133,11 @@ export class Scorm2004DataSerializer {
    */
   renderCommitObject(terminateCommit: boolean, includeTotalTime: boolean = false): CommitObject {
     const cmiExport = this.renderCommitCMI(terminateCommit, includeTotalTime);
+    // renderCommitCMI adds compact-only metadata at the payload root. Structured commits expose
+    // that metadata beside runtimeData instead, retaining the pre-existing runtimeData format.
+    if (!Array.isArray(cmiExport)) {
+      delete cmiExport.sharedData;
+    }
     const calculateTotalTime = terminateCommit || includeTotalTime;
     const totalTimeDuration = calculateTotalTime ? this.context.cmi.getCurrentTotalTime() : "";
     const totalTimeSeconds = getDurationAsSeconds(totalTimeDuration, scorm2004_regex.CMITimespan);
@@ -168,6 +205,10 @@ export class Scorm2004DataSerializer {
       totalTimeSeconds: totalTimeSeconds,
       runtimeData: cmiExport as StringKeyMap,
     };
+    const sharedData = this.captureSharedData();
+    if (sharedData) {
+      commitObject.sharedData = sharedData;
+    }
     if (scoreObject) {
       commitObject.score = scoreObject;
     }

--- a/src/services/ActivityDeliveryService.ts
+++ b/src/services/ActivityDeliveryService.ts
@@ -89,19 +89,19 @@ export class ActivityDeliveryService {
     // Log delivery
     this.loggingService.info(`Delivering activity: ${activity.id} - ${activity.title}`);
 
-    // Fire delivery event
-    this.eventService.processListeners("ActivityDelivery", activity.id, activity);
-
-    // Call delivery callback
-    this.callbacks.onDeliverActivity?.(activity);
-
-    // Update current delivered activity
+    // Publish the delivery state before either callback or event observers run. Generic
+    // ActivityDelivery listeners may inspect both the activity and this service's state.
     this.currentDeliveredActivity = activity;
     this.currentDeliveredAttemptCount = activity.attemptCount;
     this.pendingDelivery = null;
-
-    // Mark activity as active
     activity.isActive = true;
+
+    // Let API-owned delivery bookkeeping install the new activity's launch-static state before
+    // generic ActivityDelivery observers inspect the public API model.
+    this.callbacks.onDeliverActivity?.(activity);
+
+    // Fire delivery event
+    this.eventService.processListeners("ActivityDelivery", activity.id, activity);
   }
 
   /**

--- a/src/services/SequencingService.ts
+++ b/src/services/SequencingService.ts
@@ -384,6 +384,12 @@ export class SequencingService {
       return true;
     } else {
       // No delivery requested or invalid
+      // End Attempt may have changed global objectives and therefore the
+      // validity of choice requests even when sequencing rejects the request
+      // or has no activity to deliver. Keep the current activity pointer in
+      // place, but refresh the derived navigation state for the LMS/UI.
+      this.overallSequencingProcess?.updateNavigationValidity();
+
       if (deliveryRequest.exception) {
         this.log("warn", `Navigation request '${request}' failed: ${deliveryRequest.exception}`);
         this.fireEvent("onSequencingError", deliveryRequest.exception, "navigation");
@@ -705,6 +711,8 @@ export class SequencingService {
   private getCMIDataForTransfer(): any {
     const cmiData: any = {
       completion_status: this.cmi.completion_status,
+      completion_status_was_set:
+        this.configuration.wasCMIElementSetByContent?.("cmi.completion_status") === true,
       success_status: this.cmi.success_status,
       // @spec SCORM 2004 4th Ed. SN 3.13.3 - auto-satisfaction applies only
       // when content did not communicate primary-objective success information.

--- a/src/types/activity_types.ts
+++ b/src/types/activity_types.ts
@@ -5,6 +5,7 @@
  */
 
 import { CompletionStatus, SuccessStatus } from "../constants/enums";
+import type { SharedDataMapSettings } from "./sequencing_types";
 
 /**
  * Interface for Activity objects passed to sequencing event listeners.
@@ -70,4 +71,7 @@ export interface IActivity {
 
   /** Whether progress measure status is valid */
   readonly progressMeasureStatus: boolean;
+
+  /** Shared-data bucket mappings declared for this activity. */
+  readonly sharedDataMaps?: SharedDataMapSettings[];
 }

--- a/src/types/api_types.ts
+++ b/src/types/api_types.ts
@@ -231,6 +231,8 @@ export type CommitObject = {
   runtimeData: StringKeyMap;
   /** SCORM 2004 sequencing global-objective state for LMS persistence. */
   globalObjectives?: Record<string, GlobalObjectiveMapEntry>;
+  /** SCORM 2004 shared-data stores keyed by manifest targetID. */
+  sharedData?: Record<string, string>;
   score?: ScoreObject;
   commitId?: string;
   courseId?: string;

--- a/src/types/sequencing_types.ts
+++ b/src/types/sequencing_types.ts
@@ -65,6 +65,13 @@ export type DeliveryControlsSettings = {
   objectiveSetByContent?: boolean;
 };
 
+/** Configuration for an activity's SCORM 2004 shared-data bucket mappings. */
+export type SharedDataMapSettings = {
+  targetID: string;
+  readSharedData?: boolean;
+  writeSharedData?: boolean;
+};
+
 export type ActivitySettings = {
   id: string;
   title: string;
@@ -96,6 +103,7 @@ export type ActivitySettings = {
   sequencingCollectionRefs?: string | string[];
   sequencingIdRef?: string | string[];
   auxiliaryResources?: AuxiliaryResourceSettings[];
+  sharedDataMaps?: SharedDataMapSettings[];
 };
 
 /**

--- a/test/api/Scorm2004API.navigation.spec.ts
+++ b/test/api/Scorm2004API.navigation.spec.ts
@@ -60,6 +60,105 @@ describe("SCORM 2004 API Navigation Request Processing Tests", () => {
   });
 
   describe("Navigation Request Processing During Terminate", () => {
+    it("refreshes rejected Choice validity after End Attempt without emitting a legacy Choice event", () => {
+      const apiInstance = api({
+        sequencing: {
+          activityTree: {
+            id: "objective-choice-root",
+            sequencingControls: { choice: true, flow: true },
+            children: [
+              {
+                id: "current",
+                primaryObjective: {
+                  objectiveID: "current-objective",
+                  mapInfo: [
+                    {
+                      targetObjectiveID: "shared-completion",
+                      readCompletionStatus: true,
+                      writeCompletionStatus: true,
+                    },
+                  ],
+                },
+                sequencingControls: { completionSetByContent: true },
+              },
+              {
+                id: "target",
+                objectives: [
+                  {
+                    objectiveID: "previous-completed",
+                    mapInfo: [
+                      {
+                        targetObjectiveID: "shared-completion",
+                        readCompletionStatus: true,
+                        writeCompletionStatus: false,
+                      },
+                    ],
+                  },
+                ],
+                sequencingRules: {
+                  preConditionRules: [
+                    {
+                      action: "disabled",
+                      conditionCombination: "any",
+                      conditions: [
+                        {
+                          condition: "completed",
+                          operator: "not",
+                          referencedObjective: "previous-completed",
+                        },
+                        {
+                          condition: "activityProgressKnown",
+                          operator: "not",
+                          referencedObjective: "previous-completed",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      });
+
+      expect(apiInstance.lmsInitialize()).toBe("true");
+      const sequencingProcess = apiInstance.getSequencingService()?.getOverallSequencingProcess();
+      expect(sequencingProcess).toBeDefined();
+
+      // Seed the shared objective as completed so the Choice request is valid
+      // before End Attempt transfers the current SCO's incomplete status.
+      sequencingProcess?.updateGlobalObjective("shared-completion", {
+        completionStatus: "completed",
+        completionStatusKnown: true,
+      });
+      sequencingProcess?.synchronizeGlobalObjectives();
+      expect(apiInstance.adl.nav.request_valid.choice._isTargetValid("target")).toBe("true");
+
+      const validityUpdates: any[] = [];
+      apiInstance.setSequencingEventListeners({
+        onNavigationValidityUpdate: (update) => validityUpdates.push(update),
+      });
+      const processListenersSpy = vi.spyOn(apiInstance, "processListeners");
+
+      expect(apiInstance.lmsSetValue("cmi.completion_status", "incomplete")).toBe("true");
+      expect(apiInstance.lmsSetValue("adl.nav.request", "{target=target}choice")).toBe("true");
+      expect(apiInstance.lmsFinish()).toBe("true");
+
+      const current = apiInstance.getSequencingState().currentActivity;
+      expect(current?.id).toBe("current");
+      expect(current?.isActive).toBe(false);
+      expect(current?.completionStatus).toBe("incomplete");
+      expect(sequencingProcess?.getGlobalObjectiveMap().get("shared-completion")).toMatchObject({
+        completionStatus: "incomplete",
+        completionStatusKnown: true,
+      });
+      expect(apiInstance.adl.nav.request_valid.choice._isTargetValid("target")).toBe("false");
+      expect(validityUpdates.some((update) => update.choice?.target === "false")).toBe(true);
+      expect(
+        processListenersSpy.mock.calls.some(([eventName]) => eventName === "SequenceChoice"),
+      ).toBe(false);
+    });
+
     it("should process navigation request during Terminate when set", () => {
       const apiInstance = apiInitialized();
 

--- a/test/cmi/scorm2004/sequencing/end_sequencing_session.spec.ts
+++ b/test/cmi/scorm2004/sequencing/end_sequencing_session.spec.ts
@@ -11,6 +11,12 @@ import {
 import { RollupProcess } from "../../../../src/cmi/scorm2004/sequencing/rollup_process";
 import { ActivityTree } from "../../../../src/cmi/scorm2004/sequencing/activity_tree";
 import { Activity } from "../../../../src/cmi/scorm2004/sequencing/activity";
+import {
+  RuleActionType,
+  RuleCondition,
+  RuleConditionType,
+  SequencingRule
+} from "../../../../src/cmi/scorm2004/sequencing/sequencing_rules";
 import { ADLNav } from "../../../../src";
 
 /**
@@ -327,6 +333,37 @@ describe("EndSequencingSession Handling", () => {
       expect(eventCallback).toHaveBeenCalledWith(
         "onSequencingSessionEnd",
         expect.objectContaining({
+          navigationRequest: NavigationRequestType.CONTINUE
+        })
+      );
+    });
+
+    it("should fire when a Continue post-condition cascade exits all activities", () => {
+      const exitParentRule = new SequencingRule(RuleActionType.EXIT_PARENT);
+      exitParentRule.addCondition(new RuleCondition(RuleConditionType.ALWAYS));
+      sco3.sequencingRules.addPostConditionRule(exitParentRule);
+
+      const exitAllRule = new SequencingRule(RuleActionType.EXIT_ALL);
+      exitAllRule.addCondition(new RuleCondition(RuleConditionType.ALWAYS));
+      root.sequencingRules.addPostConditionRule(exitAllRule);
+
+      activityTree.currentActivity = sco3;
+      root.isActive = true;
+      sco3.isActive = true;
+      eventCallback.mockClear();
+
+      const delivery = overallProcess.processNavigationRequest(
+        NavigationRequestType.CONTINUE
+      );
+
+      expect(delivery.valid).toBe(true);
+      expect(delivery.targetActivity).toBeNull();
+      expect(delivery.exception).toBeNull();
+      expect(activityTree.currentActivity).toBeNull();
+      expect(eventCallback).toHaveBeenCalledWith(
+        "onSequencingSessionEnd",
+        expect.objectContaining({
+          reason: "exit_all",
           navigationRequest: NavigationRequestType.CONTINUE
         })
       );

--- a/test/cmi/scorm2004/sequencing/objective_delivery_seeding.spec.ts
+++ b/test/cmi/scorm2004/sequencing/objective_delivery_seeding.spec.ts
@@ -105,6 +105,67 @@ const TERMINATION_COMMIT_OBJECTIVE_TREE = {
   ],
 };
 
+const DELIVERY_READ_MAP_NAVIGATION_TREE = {
+  id: "delivery-read-map-navigation",
+  title: "Delivery read-map navigation",
+  sequencingControls: {
+    choice: true,
+    flow: true,
+  },
+  children: [
+    {
+      id: "activity_1",
+      title: "Activity 1",
+      primaryObjective: {
+        objectiveID: "activity_1_completed",
+        mapInfo: [
+          {
+            targetObjectiveID: "global_activity_1_completed",
+            readCompletionStatus: true,
+            writeCompletionStatus: true,
+          },
+        ],
+      },
+    },
+    {
+      id: "activity_2",
+      title: "Activity 2",
+      objectives: [
+        {
+          objectiveID: "previous_sco_completed",
+          mapInfo: [
+            {
+              targetObjectiveID: "global_activity_1_completed",
+              readCompletionStatus: true,
+              writeCompletionStatus: false,
+            },
+          ],
+        },
+      ],
+      sequencingRules: {
+        preConditionRules: [
+          {
+            action: "disabled",
+            conditionCombination: "any",
+            conditions: [
+              {
+                condition: "completed",
+                operator: "not",
+                referencedObjective: "previous_sco_completed",
+              },
+              {
+                condition: "activityProgressKnown",
+                operator: "not",
+                referencedObjective: "previous_sco_completed",
+              },
+            ],
+          },
+        ],
+      },
+    },
+  ],
+};
+
 const SX_11B_COMPLETION_CLEAR_TREE = {
   id: "sx-11b-completion-clear",
   title: "SX-11b Completion Clear",
@@ -583,6 +644,30 @@ describe("SCORM 2004 sequencing objective delivery seeding", () => {
     expect(api.lmsGetValue("cmi.objectives.0.success_status")).toBe("unknown");
   });
 
+  it("reapplies a read-mapped completion after new-attempt initialization", () => {
+    const api = createApi(DELIVERY_READ_MAP_NAVIGATION_TREE);
+
+    expect(api.lmsInitialize("")).toBe("true");
+    expect(api.lmsSetValue("cmi.completion_status", "completed")).toBe("true");
+    continueToNextActivity(api);
+
+    const activity2 = childActivity(api, "activity_2");
+    const previousScoObjective = activity2?.getObjectiveById("previous_sco_completed")?.objective;
+    expect(api.getSequencingState().currentActivity?.id).toBe("activity_2");
+    expect(previousScoObjective?.completionStatus).toBe("completed");
+    expect(
+      api
+        .getSequencingService()
+        ?.getOverallSequencingProcess()
+        ?.predictChoiceEnabled("activity_2"),
+    ).toBe(true);
+
+    prepareNextVisit(api);
+    // The current activity remains a valid Choice target after its prerequisite
+    // read map is restored; the LMS must not render delivered content as locked.
+    expect(api.lmsGetValue("adl.nav.request_valid.choice.{target=activity_2}")).toBe("true");
+  });
+
   it("seeds a read map before the delivered objective becomes the next writer", () => {
     const api = createApi({
       id: "read-write-objective-map",
@@ -643,6 +728,14 @@ describe("SCORM 2004 sequencing objective delivery seeding", () => {
     // delivery reads the prior global value before local writes can update it.
     expect(api.lmsGetValue(`cmi.objectives.${objectiveIndex}.success_status`)).toBe("passed");
     expect(api.lmsGetValue(`cmi.objectives.${objectiveIndex}.score.scaled`)).toBe("0.5");
+
+    const deliveredObjective = childActivity(api, "activity_2")?.getObjectiveById(
+      "reader-writer",
+    )?.objective;
+    expect(deliveredObjective?.satisfiedStatusKnown).toBe(true);
+    expect(deliveredObjective?.satisfiedStatus).toBe(true);
+    expect(deliveredObjective?.measureStatus).toBe(true);
+    expect(deliveredObjective?.normalizedMeasure).toBe(0.5);
   });
 
   it("writes an explicitly unknown objective satisfaction status to the global map", () => {

--- a/test/cmi/scorm2004/sequencing/rte_data_transfer.spec.ts
+++ b/test/cmi/scorm2004/sequencing/rte_data_transfer.spec.ts
@@ -478,6 +478,35 @@ describe("RTE Data Transfer", () => {
       expect(leafActivity.successStatus).toBe("failed");
     });
 
+    it("should not let launch-seeded primary completion override top-level content completion", () => {
+      const transfer = new RteDataTransferService({
+        getCMIData: null,
+        fireEvent: () => undefined,
+      });
+      const cmiData: CMIDataForTransfer = {
+        completion_status: "completed",
+        completion_status_was_set: true,
+        success_status: "unknown",
+        objectives: [
+          {
+            id: "primary_obj",
+            completion_status: "incomplete",
+            completion_status_was_set: false,
+          },
+        ],
+      };
+
+      transfer.transferPrimaryObjective(leafActivity, cmiData);
+      transfer.transferNonPrimaryObjectives(leafActivity, cmiData);
+
+      // The LMS seeds the primary cmi.objectives row at delivery. If content
+      // later writes only cmi.completion_status, that top-level primary value
+      // is authoritative at End Attempt.
+      expect(leafActivity.completionStatus).toBe(CompletionStatus.COMPLETED);
+      expect(leafActivity.attemptProgressStatus).toBe(true);
+      expect(leafActivity.primaryObjective?.completionStatus).toBe(CompletionStatus.COMPLETED);
+    });
+
     it("should not let a launch-seeded primary objective override a top-level content score", () => {
       const transfer = new RteDataTransferService({
         getCMIData: null,

--- a/test/cmi/scorm2004/sequencing/simple_remediation.spec.ts
+++ b/test/cmi/scorm2004/sequencing/simple_remediation.spec.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "vitest";
+import Scorm2004API from "../../../../src/Scorm2004API";
+import { LogLevelEnum } from "../../../../src/constants/enums";
+
+const objective = (targetObjectiveID: string, writeSatisfiedStatus: boolean) => ({
+  objectiveID: "learning_objective_satisfied",
+  mapInfo: [
+    {
+      targetObjectiveID,
+      readSatisfiedStatus: true,
+      writeSatisfiedStatus,
+      writeNormalizedMeasure: writeSatisfiedStatus,
+    },
+  ],
+});
+
+const skipIfSatisfied = {
+  preConditionRules: [
+    {
+      action: "skip",
+      conditionCombination: "all",
+      conditions: [{ condition: "satisfied" }],
+    },
+  ],
+};
+
+const contentActivity = (id: string, targetObjectiveID: string) => ({
+  id,
+  title: id,
+  sequencingRules: skipIfSatisfied,
+  sequencingControls: {
+    rollupObjectiveSatisfied: false,
+    rollupProgressCompletion: false,
+    objectiveMeasureWeight: 0,
+    completionSetByContent: true,
+    objectiveSetByContent: true,
+  },
+  primaryObjective: objective(targetObjectiveID, false),
+});
+
+const testActivity = (id: string, targetObjectiveID: string, last = false) => ({
+  id,
+  title: id,
+  sequencingRules: {
+    ...skipIfSatisfied,
+    ...(last
+      ? {
+          postConditionRules: [
+            {
+              action: "exitParent",
+              conditionCombination: "all",
+              conditions: [{ condition: "always" }],
+            },
+          ],
+        }
+      : {}),
+  },
+  sequencingControls: {
+    rollupObjectiveSatisfied: true,
+    rollupProgressCompletion: true,
+    objectiveMeasureWeight: 1,
+    completionSetByContent: true,
+    objectiveSetByContent: true,
+  },
+  rollupConsiderations: {
+    requiredForCompleted: "ifNotSkipped",
+  },
+  primaryObjective: objective(targetObjectiveID, true),
+});
+
+const SIMPLE_REMEDIATION_TREE = {
+  id: "simple_remediation",
+  title: "Simple remediation",
+  sequencingControls: {
+    choice: false,
+    flow: true,
+  },
+  children: [
+    {
+      id: "content_wrapper",
+      title: "Remediation wrapper",
+      sequencingControls: {
+        choice: false,
+        flow: true,
+        choiceExit: false,
+      },
+      sequencingRules: {
+        postConditionRules: [
+          {
+            action: "retry",
+            conditionCombination: "any",
+            conditions: [
+              { condition: "satisfied", operator: "not" },
+              { condition: "objectiveStatusKnown", operator: "not" },
+            ],
+          },
+          {
+            action: "exitAll",
+            conditionCombination: "any",
+            conditions: [{ condition: "satisfied" }],
+          },
+        ],
+      },
+      children: [
+        contentActivity("content_1", "global_1"),
+        contentActivity("content_2", "global_2"),
+        testActivity("test_1", "global_1"),
+        testActivity("test_2", "global_2", true),
+      ],
+    },
+  ],
+};
+
+function createApi(): Scorm2004API {
+  return new Scorm2004API({
+    autocommit: false,
+    logLevel: LogLevelEnum.NONE,
+    sequencing: {
+      activityTree: SIMPLE_REMEDIATION_TREE as any,
+    },
+  });
+}
+
+function currentActivityId(api: Scorm2004API): string | undefined {
+  return api.getSequencingState().currentActivity?.id;
+}
+
+function beginVisit(api: Scorm2004API): void {
+  api.reset();
+  expect(api.lmsInitialize("")).toBe("true");
+}
+
+function finishAndContinue(
+  api: Scorm2004API,
+  successStatus?: "passed" | "failed",
+): void {
+  expect(api.lmsSetValue("cmi.completion_status", "completed")).toBe("true");
+  if (successStatus) {
+    expect(api.lmsSetValue("cmi.success_status", successStatus)).toBe("true");
+    expect(api.lmsSetValue("cmi.score.scaled", successStatus === "passed" ? "1" : "0")).toBe(
+      "true",
+    );
+  }
+  expect(api.lmsSetValue("cmi.exit", "normal")).toBe("true");
+  expect(api.lmsSetValue("adl.nav.request", "_continue")).toBe("true");
+  expect(api.lmsFinish("")).toBe("true");
+}
+
+describe("SCORM 2004 simple remediation", () => {
+  it("exits after a failed objective is remediated while mastered siblings are skipped", () => {
+    const api = createApi();
+
+    expect(api.lmsInitialize("")).toBe("true");
+    expect(currentActivityId(api)).toBe("content_1");
+
+    finishAndContinue(api);
+    expect(currentActivityId(api)).toBe("content_2");
+    beginVisit(api);
+
+    finishAndContinue(api);
+    expect(currentActivityId(api)).toBe("test_1");
+    beginVisit(api);
+
+    finishAndContinue(api, "passed");
+    expect(currentActivityId(api)).toBe("test_2");
+    beginVisit(api);
+
+    finishAndContinue(api, "failed");
+    expect(currentActivityId(api)).toBe("content_2");
+    beginVisit(api);
+
+    finishAndContinue(api);
+    expect(currentActivityId(api)).toBe("test_2");
+    beginVisit(api);
+
+    finishAndContinue(api, "passed");
+
+    const root = api.getSequencingState().rootActivity;
+    const wrapper = root?.children[0];
+    const masteredContent = wrapper?.children.find((activity) => activity.id === "content_1");
+    const masteredTest = wrapper?.children.find((activity) => activity.id === "test_1");
+
+    expect(masteredContent?.wasSkipped).toBe(true);
+    expect(masteredTest?.wasSkipped).toBe(true);
+    expect(masteredTest?.objectiveInfoAvailableInCurrentParentAttempt).toBe(true);
+    expect(masteredTest?.requiredForCompleted).toBe("ifNotSkipped");
+    expect(wrapper?.objectiveSatisfiedStatusKnown).toBe(true);
+    expect(wrapper?.objectiveSatisfiedStatus).toBe(true);
+    expect(wrapper?.completionStatus).toBe("completed");
+    expect(currentActivityId(api)).toBeUndefined();
+  });
+});

--- a/test/cmi/scorm2004/shared_data.spec.ts
+++ b/test/cmi/scorm2004/shared_data.spec.ts
@@ -1,0 +1,270 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import Scorm2004API from "../../../src/Scorm2004API";
+import { LogLevelEnum, scorm2004_errors } from "../../../src/constants";
+
+const TARGET = "com.scorm.golfsamples.sequencing.forcedsequential.notesStorage";
+const SECOND_TARGET = "com.scorm.golfsamples.sequencing.forcedsequential.secondStorage";
+const READ_ONLY_TARGET = "com.scorm.golfsamples.sequencing.forcedsequential.readOnlyStorage";
+const UNMAPPED_TARGET = "com.scorm.golfsamples.sequencing.forcedsequential.unmappedStorage";
+const UNINITIALIZED_TARGET =
+  "com.scorm.golfsamples.sequencing.forcedsequential.uninitializedStorage";
+
+const settings = () => ({
+  logLevel: LogLevelEnum.NONE,
+  sequencing: {
+    activityTree: {
+      id: "course",
+      title: "Course",
+      children: [
+        {
+          id: "first",
+          title: "First",
+          sharedDataMaps: [{ targetID: TARGET, readSharedData: true, writeSharedData: true }],
+        },
+        {
+          id: "second",
+          title: "Second",
+          sharedDataMaps: [{ targetID: TARGET, readSharedData: true, writeSharedData: true }],
+        },
+      ],
+    },
+  },
+});
+
+const distinctActivitySettings = () => ({
+  logLevel: LogLevelEnum.NONE,
+  sequencing: {
+    activityTree: {
+      id: "course",
+      title: "Course",
+      sequencingControls: { flow: true },
+      children: [
+        {
+          id: "first",
+          title: "First",
+          sharedDataMaps: [{ targetID: TARGET, readSharedData: true, writeSharedData: true }],
+        },
+        {
+          id: "second",
+          title: "Second",
+          sharedDataMaps: [
+            { targetID: SECOND_TARGET, readSharedData: true, writeSharedData: true },
+          ],
+        },
+      ],
+    },
+  },
+});
+
+describe("SCORM 2004 shared data", () => {
+  let api: Scorm2004API;
+
+  beforeEach(() => {
+    api = new Scorm2004API(settings());
+    api.lmsInitialize();
+  });
+
+  it("keeps a missing bucket uninitialized and preserves values across a mapped view change", () => {
+    expect(api.lmsGetValue("adl.data._count")).toBe("1");
+    expect(api.lmsGetValue("adl.data.0.id")).toBe(TARGET);
+    expect(api.lmsGetLastError()).toBe("0");
+    expect(api.lmsGetValue("adl.data.0.store")).toBe("");
+    expect(api.lmsGetLastError()).toBe(String(scorm2004_errors.VALUE_NOT_INITIALIZED));
+
+    expect(api.lmsSetValue("adl.data.0.store", "")).toBe("true");
+    expect(api.lmsGetValue("adl.data.0.store")).toBe("");
+    expect(api.lmsGetLastError()).toBe("0");
+    expect(api.captureSharedDataSnapshot()).toEqual({ [TARGET]: "" });
+
+    expect(api.lmsSetValue("adl.data.0.store", "notes")).toBe("true");
+    expect(api.captureSharedDataSnapshot()).toEqual({ [TARGET]: "notes" });
+
+    api.adl.configureSharedDataMaps([
+      { targetID: TARGET, readSharedData: true, writeSharedData: true },
+    ]);
+    expect(api.lmsGetValue("adl.data.0.store")).toBe("notes");
+  });
+
+  it("enforces read and write map flags with SCORM 2004 errors", () => {
+    api.adl.configureSharedDataMaps([
+      { targetID: TARGET, readSharedData: false, writeSharedData: true },
+    ]);
+    expect(api.lmsGetValue("adl.data.0.store")).toBe("");
+    expect(api.lmsGetLastError()).toBe(String(scorm2004_errors.WRITE_ONLY_ELEMENT));
+    expect(api.lmsSetValue("adl.data.0.store", "write-only")).toBe("true");
+
+    api.adl.configureSharedDataMaps([
+      { targetID: TARGET, readSharedData: true, writeSharedData: false },
+    ]);
+    expect(api.lmsGetValue("adl.data.0.store")).toBe("write-only");
+    expect(api.lmsSetValue("adl.data.0.store", "blocked")).toBe("false");
+    expect(api.lmsGetLastError()).toBe(String(scorm2004_errors.READ_ONLY_ELEMENT));
+  });
+
+  it("projects ADL data and all shared stores into commits and state snapshots", () => {
+    api.lmsSetValue("adl.data.0.store", "persisted");
+    const commit = api.renderCommitObject(false);
+    expect((commit.runtimeData.adl as any).data["0"].store).toBe("persisted");
+    expect(commit.sharedData).toEqual({ [TARGET]: "persisted" });
+
+    const state = JSON.parse(api.serializeSequencingState());
+    expect(state.sharedData).toEqual({ [TARGET]: "persisted" });
+
+    const restored = new Scorm2004API(settings());
+    restored.restoreSharedDataSnapshot({ [TARGET]: "restored" });
+    restored.lmsInitialize();
+    expect(restored.lmsGetValue("adl.data.0.store")).toBe("restored");
+  });
+
+  it("includes mapped shared data in the default compact commit payload", () => {
+    const processHttpRequest = vi.fn(() => ({ result: "true", errorCode: 0 }));
+    const compactApi = new Scorm2004API({ ...settings(), lmsCommitUrl: "/commit" }, {
+      processHttpRequest,
+    } as any);
+    compactApi.lmsInitialize();
+    compactApi.lmsSetValue("adl.data.0.store", "compact-payload");
+
+    expect(compactApi.lmsCommit()).toBe("true");
+    expect(processHttpRequest).toHaveBeenCalledOnce();
+    expect(processHttpRequest.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({ sharedData: { [TARGET]: "compact-payload" } }),
+    );
+  });
+
+  it("filters structured shared data to initialized writable mappings", () => {
+    api.adl.configureSharedDataMaps([
+      { targetID: TARGET, readSharedData: true, writeSharedData: true },
+      { targetID: READ_ONLY_TARGET, readSharedData: true, writeSharedData: false },
+      { targetID: UNINITIALIZED_TARGET, readSharedData: true, writeSharedData: true },
+    ]);
+    api.restoreSharedDataSnapshot({
+      [TARGET]: "writable",
+      [READ_ONLY_TARGET]: "read-only",
+      [UNMAPPED_TARGET]: "unmapped",
+    });
+
+    expect(api.captureSharedDataSnapshot()).toEqual({
+      [TARGET]: "writable",
+      [READ_ONLY_TARGET]: "read-only",
+      [UNMAPPED_TARGET]: "unmapped",
+    });
+    expect(api.renderCommitObject(false).sharedData).toEqual({ [TARGET]: "writable" });
+  });
+
+  it("filters compact JSON shared data to initialized writable mappings", () => {
+    const processHttpRequest = vi.fn(() => ({ result: "true", errorCode: 0 }));
+    const compactApi = new Scorm2004API({ ...settings(), lmsCommitUrl: "/commit" }, {
+      processHttpRequest,
+    } as any);
+    compactApi.lmsInitialize();
+    compactApi.adl.configureSharedDataMaps([
+      { targetID: TARGET, readSharedData: true, writeSharedData: true },
+      { targetID: READ_ONLY_TARGET, readSharedData: true, writeSharedData: false },
+      { targetID: UNINITIALIZED_TARGET, readSharedData: true, writeSharedData: true },
+    ]);
+    compactApi.restoreSharedDataSnapshot({
+      [TARGET]: "writable",
+      [READ_ONLY_TARGET]: "read-only",
+      [UNMAPPED_TARGET]: "unmapped",
+    });
+
+    expect(compactApi.lmsCommit()).toBe("true");
+    expect(processHttpRequest.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({ sharedData: { [TARGET]: "writable" } }),
+    );
+  });
+
+  it("treats a restored snapshot as authoritative", () => {
+    api.restoreSharedDataSnapshot({ [TARGET]: "stale", unrelated: "remove me" });
+    api.restoreSharedDataSnapshot({});
+
+    expect(api.lmsGetValue("adl.data.0.store")).toBe("");
+    expect(api.lmsGetLastError()).toBe(String(scorm2004_errors.VALUE_NOT_INITIALIZED));
+    expect(api.captureSharedDataSnapshot()).toEqual({});
+  });
+
+  it("rebuilds mapped buckets as uninitialized while preserving stores across API reset", () => {
+    expect(api.lmsSetValue("adl.data.0.store", "survives reset")).toBe("true");
+
+    api.reset();
+
+    expect(api.adl.data.initialized).toBe(false);
+    expect(api.adl.data.childArray[0].initialized).toBe(false);
+    expect(api.lmsInitialize()).toBe("true");
+    expect(api.lmsGetValue("adl.data.0.store")).toBe("survives reset");
+  });
+
+  it("does not add empty shared-data fields when no mappings or stores are used", () => {
+    const noSharedDataApi = new Scorm2004API({ logLevel: LogLevelEnum.NONE });
+    noSharedDataApi.lmsInitialize();
+
+    const commit = noSharedDataApi.renderCommitObject(false);
+    expect(commit.runtimeData.adl).toBeUndefined();
+    expect(commit.sharedData).toBeUndefined();
+  });
+
+  it("rebinds ADL data mappings to the restored activity before Initialize", () => {
+    const source = new Scorm2004API(distinctActivitySettings());
+    source.lmsInitialize();
+    source.lmsSetValue("adl.data.0.store", "first-value");
+    source.lmsSetValue("adl.nav.request", "continue");
+    source.lmsFinish();
+
+    const restored = new Scorm2004API(distinctActivitySettings());
+    expect(restored.deserializeSequencingState(source.serializeSequencingState())).toBe(true);
+    expect(restored.adl.data.childArray[0].id).toBe(SECOND_TARGET);
+    expect(restored.lmsInitialize()).toBe("true");
+    expect(restored.lmsGetValue("adl.data.0.store")).toBe("");
+    expect(restored.lmsGetLastError()).toBe(String(scorm2004_errors.VALUE_NOT_INITIALIZED));
+  });
+
+  it("rebinds ADL data mappings after an asynchronous auto-load", async () => {
+    const source = new Scorm2004API(distinctActivitySettings());
+    source.lmsInitialize();
+    source.lmsSetValue("adl.data.0.store", "first-value");
+    source.lmsSetValue("adl.nav.request", "continue");
+    source.lmsFinish();
+    const state = source.serializeSequencingState();
+
+    let resolveLoad: ((value: string) => void) | undefined;
+    const loadState = new Promise<string>((resolve) => {
+      resolveLoad = resolve;
+    });
+    const restored = new Scorm2004API({
+      ...distinctActivitySettings(),
+      sequencingStatePersistence: {
+        persistence: {
+          saveState: async () => true,
+          loadState: async () => loadState,
+        },
+        compress: false,
+      },
+    });
+
+    expect(restored.lmsInitialize()).toBe("true");
+    expect(restored.adl.data.childArray[0].id).toBe(TARGET);
+    resolveLoad?.(state);
+
+    await vi.waitFor(() => expect(restored.adl.data.childArray[0].id).toBe(SECOND_TARGET));
+  });
+
+  it("exposes the delivered activity's mappings to generic ActivityDelivery listeners", () => {
+    const delivered: Array<{ activityId: string; mappedTarget: string }> = [];
+    const observed = new Scorm2004API(distinctActivitySettings());
+    observed.on("ActivityDelivery", (activityId) => {
+      delivered.push({
+        activityId: String(activityId),
+        mappedTarget: observed.adl.data.childArray[0]?.id ?? "",
+      });
+    });
+
+    expect(observed.lmsInitialize()).toBe("true");
+    expect(observed.lmsSetValue("adl.nav.request", "continue")).toBe("true");
+    expect(observed.lmsFinish()).toBe("true");
+
+    expect(delivered).toEqual([
+      { activityId: "first", mappedTarget: TARGET },
+      { activityId: "second", mappedTarget: SECOND_TARGET },
+    ]);
+  });
+});

--- a/test/integration/SequencingPostTestRollup4thEd_SCORM20044thEdition.spec.ts
+++ b/test/integration/SequencingPostTestRollup4thEd_SCORM20044thEdition.spec.ts
@@ -56,6 +56,7 @@ import { scorm2004InteractionsObjectivesTests } from "./suites/scorm2004-interac
 // Module path - first SCO in the sequence
 const MODULE_PATH =
   "/test/integration/modules/SequencingPostTestRollup4thEd_SCORM20044thEdition/shared/launchpage.html?content=playing";
+const NOTES_STORAGE = "com.scorm.golfsamples.sequencing.forcedsequential.notesStorage";
 
 // Activity tree configuration based on manifest analysis
 const ACTIVITY_TREE = {
@@ -66,6 +67,7 @@ const ACTIVITY_TREE = {
       id: "playing_item",
       title: "Playing the Game",
       identifierref: "playing_resource",
+      sharedDataMaps: [{ targetID: NOTES_STORAGE, readSharedData: true, writeSharedData: true }],
       objectives: [
         {
           objectiveID: "playing_completed",
@@ -90,6 +92,7 @@ const ACTIVITY_TREE = {
       id: "etuqiette_item",
       title: "Etiquette",
       identifierref: "etiquette_resource",
+      sharedDataMaps: [{ targetID: NOTES_STORAGE, readSharedData: true, writeSharedData: true }],
       objectives: [
         {
           objectiveID: "ettiquette_completed",
@@ -146,6 +149,7 @@ const ACTIVITY_TREE = {
       id: "handicapping_item",
       title: "Handicapping",
       identifierref: "handicapping_resource",
+      sharedDataMaps: [{ targetID: NOTES_STORAGE, readSharedData: true, writeSharedData: true }],
       objectives: [
         {
           objectiveID: "handicapping_completed",
@@ -202,6 +206,7 @@ const ACTIVITY_TREE = {
       id: "havingfun_item",
       title: "Having Fun",
       identifierref: "havingfun_resource",
+      sharedDataMaps: [{ targetID: NOTES_STORAGE, readSharedData: true, writeSharedData: true }],
       objectives: [
         {
           objectiveID: "havingfun_completed",
@@ -258,6 +263,7 @@ const ACTIVITY_TREE = {
       id: "assessment_item",
       title: "Quiz",
       identifierref: "assessment_resource",
+      sharedDataMaps: [{ targetID: NOTES_STORAGE, readSharedData: true, writeSharedData: true }],
       objectives: [
         {
           objectiveID: "previous_sco_completed",
@@ -1193,35 +1199,53 @@ wrappers.forEach((wrapper) => {
       await page.goto(`${wrapper.path}?module=${MODULE_PATH}`);
       await waitForPageReady(page);
 
-      // Inject sequencing configuration
       await injectSequencingConfig(page, ACTIVITY_TREE, SEQUENCING_CONTROLS);
       await ensureApiInitialized(page);
       await page.waitForTimeout(2000);
 
-      // Verify shared data bucket configuration
-      // Note: Shared data buckets are configured in the activity tree
-      // but may not be directly accessible via the API
-      // This test verifies the configuration is present
-      const hasSharedDataConfig = await page.evaluate(() => {
+      const initial = await page.evaluate((targetId) => {
         const api = (window as any).API_1484_11;
-        const state = api.getSequencingState();
+        const count = api.lmsGetValue("adl.data._count");
+        const id = api.lmsGetValue("adl.data.0.id");
+        const store = api.lmsGetValue("adl.data.0.store");
+        const storeError = api.lmsGetLastError();
+        return { count, id, store, storeError, targetId };
+      }, NOTES_STORAGE);
 
-        // Check if activities have shared data configuration
-        if (state?.rootActivity?.children) {
-          for (const child of state.rootActivity.children) {
-            // Shared data buckets are typically configured at the activity level
-            // but may not be directly exposed in the sequencing state
-            // The presence of the activity indicates configuration is loaded
-            if (child.id === "playing_item") {
-              return true;
-            }
-          }
-        }
-        return false;
+      expect(initial.count).toBe("1");
+      expect(initial.id).toBe(NOTES_STORAGE);
+      expect(initial.store).toBe("");
+      expect(initial.storeError).toBe(String(403));
+
+      const afterNavigation = await page.evaluate((note) => {
+        const api = (window as any).API_1484_11;
+        const writeResult = api.lmsSetValue("adl.data.0.store", note);
+        api.lmsSetValue("cmi.completion_status", "completed");
+        api.lmsCommit("");
+        api.lmsSetValue("adl.nav.request", "_continue");
+        api.processNavigationRequest("continue");
+        api.reset();
+        api.lmsInitialize("");
+        return {
+          writeResult,
+          currentActivity: api.getSequencingState()?.currentActivity?.id || null,
+          count: api.lmsGetValue("adl.data._count"),
+          id: api.lmsGetValue("adl.data.0.id"),
+          store: api.lmsGetValue("adl.data.0.store"),
+          error: api.lmsGetLastError(),
+          snapshot: api.captureSharedDataSnapshot(),
+        };
+      }, "Remember the etiquette section");
+
+      expect(afterNavigation.writeResult).toBe("true");
+      expect(afterNavigation.currentActivity).toBe("etuqiette_item");
+      expect(afterNavigation.count).toBe("1");
+      expect(afterNavigation.id).toBe(NOTES_STORAGE);
+      expect(afterNavigation.store).toBe("Remember the etiquette section");
+      expect(afterNavigation.error).toBe("0");
+      expect(afterNavigation.snapshot).toEqual({
+        [NOTES_STORAGE]: "Remember the etiquette section",
       });
-
-      // Activities should be configured (shared data is part of manifest configuration)
-      expect(hasSharedDataConfig).toBe(true);
     });
 
     /**
@@ -1495,6 +1519,13 @@ wrappers.forEach((wrapper) => {
         return null;
       });
       expect(previousScoCompletionStatus).toBe("completed");
+
+      // The delivered Etiquette attempt must retain the same read-mapped value in
+      // sequencing state. Otherwise its disabled rule treats the current SCO as
+      // prerequisite-locked even though the LMS has already delivered it.
+      expect(await getCmiValue(page, "adl.nav.request_valid.choice.{target=etuqiette_item}")).toBe(
+        "true",
+      );
 
       const globalStatus = await getGlobalObjectiveStatus(
         page,

--- a/test/integration/helpers/scorm2004-helpers.ts
+++ b/test/integration/helpers/scorm2004-helpers.ts
@@ -680,10 +680,20 @@ async function getQuizContentFrame(page: Page, moduleFrame: FrameLocator): Promi
   const iframeTimeout = isFirefox ? 20000 : 10000;
   const contentTimeout = isFirefox ? 20000 : 10000;
 
-  // The quiz is in a nested iframe with id="contentFrame"
-  // Wait for the iframe element to exist in the module frame
-  // Firefox needs more time for iframe creation
-  await moduleFrame.locator("#contentFrame").waitFor({ timeout: iframeTimeout, state: "attached" });
+  // The quiz is in a nested iframe with id="contentFrame". Waiting only for
+  // the outer module URL is racy in Firefox: the launch page can be visible
+  // while it is still creating and loading this nested frame. Wait until the
+  // nested document has a body, then use the FrameLocator for normal waits.
+  await page.waitForFunction(
+    () => {
+      const moduleFrame = document.getElementById("moduleFrame") as HTMLIFrameElement | null;
+      const contentFrame = moduleFrame?.contentDocument?.getElementById(
+        "contentFrame"
+      ) as HTMLIFrameElement | null;
+      return Boolean(contentFrame?.contentDocument?.body);
+    },
+    { timeout: iframeTimeout }
+  );
 
   // Additional wait for Firefox - iframe may exist but not be ready
   if (isFirefox) {
@@ -1266,16 +1276,6 @@ export async function completeAssessmentSCO(
   // Detect browser type for Firefox-specific timeouts
   const browserName = page.context().browser()?.browserType().name() || "chromium";
   const isFirefox = browserName === "firefox";
-  const iframeTimeout = isFirefox ? 20000 : 10000;
-
-  // Wait for the contentFrame iframe to be created (launchpage.html creates it)
-  // Firefox needs more time for iframe creation
-  await moduleFrame.locator("#contentFrame").waitFor({ state: "attached", timeout: iframeTimeout });
-
-  // Additional wait for Firefox - iframe may exist but not be ready
-  if (isFirefox) {
-    await page.waitForTimeout(500);
-  }
 
   // Answer questions correctly or incorrectly based on shouldPass parameter
   if (shouldPass) {

--- a/test/services/ActivityDeliveryService.spec.ts
+++ b/test/services/ActivityDeliveryService.spec.ts
@@ -79,6 +79,31 @@ describe("ActivityDeliveryService", () => {
       expect(activity.isActive).toBe(true);
     });
 
+    it("should publish the new delivery state before generic listeners run", () => {
+      const activity = new Activity("activity1", "Activity 1");
+      activity.incrementAttemptCount();
+      let observed: {
+        current: Activity | null;
+        attemptCount: number;
+        isActive: boolean;
+      } | null = null;
+      eventService.on("ActivityDelivery", (_activityId, deliveredActivity) => {
+        observed = {
+          current: activityDeliveryService.getCurrentDeliveredActivity(),
+          attemptCount: (deliveredActivity as Activity).attemptCount,
+          isActive: (deliveredActivity as Activity).isActive,
+        };
+      });
+
+      activityDeliveryService.processSequencingResult({
+        exception: null,
+        deliveryRequest: DeliveryRequestType.DELIVER,
+        targetActivity: activity,
+      });
+
+      expect(observed).toEqual({ current: activity, attemptCount: 1, isActive: true });
+    });
+
     it("should handle sequencing result with no delivery request", () => {
       const result: SequencingResult = {
         exception: null,

--- a/test/services/SequencingService.spec.ts
+++ b/test/services/SequencingService.spec.ts
@@ -22,7 +22,7 @@ describe("SequencingService", () => {
     sequencing = new Sequencing();
     cmi = new CMI();
     adl = new ADL();
-    eventService = new EventService();
+    eventService = new EventService(() => {});
     loggingService = new LoggingService();
 
     configuration = {
@@ -153,7 +153,7 @@ describe("SequencingService", () => {
       expect(result).toBe(false);
     });
 
-    it("should reject navigation requests when not initialized", () => {
+    it("should support navigation as soon as sequencing processes are created", () => {
       const uninitializedService = new SequencingService(
         sequencing,
         cmi,
@@ -164,7 +164,7 @@ describe("SequencingService", () => {
       );
 
       const result = uninitializedService.processNavigationRequest("continue");
-      expect(result).toBe(false);
+      expect(result).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary
- restore read-mapped global objective state during activity delivery and apply rollup considerations consistently
- implement manifest-mapped SCORM 2004 `adl.data` shared stores, snapshots, serialization, and restore support
- make termination, navigation delivery, and terminal session events operate on the correct outgoing activity
- add regressions for the 4th Edition post-test rollup and simple-remediation packages
- harden nested assessment-frame readiness in Firefox integration tests

## Testing
- `npm test` — 6,945 passed
- `npm run lint`
- `npm run build:all`
- Chromium integration matrix — 1,140 passed
- affected Firefox sequencing spec repeated 3x — 246 passed
- Firefox integration matrix — 1,139 passed; one unrelated single-SCO timeout passed 6/6 on immediate focused rerun