### PR TITLE
fix(scorm2004): preserve attempts across Suspend All and Choice

### DIFF
--- a/src/cmi/scorm2004/sequencing/handlers/choice_request_handler.ts
+++ b/src/cmi/scorm2004/sequencing/handlers/choice_request_handler.ts
@@ -7,7 +7,7 @@ import { RuleActionType } from "../sequencing_rules";
 import {
   SequencingResult,
   DeliveryRequestType,
-  ChoiceTraversalResult
+  ChoiceTraversalResult,
 } from "../rules/sequencing_request_types";
 
 /**
@@ -25,7 +25,7 @@ export class ChoiceRequestHandler {
     private activityTree: ActivityTree,
     private constraintValidator: ChoiceConstraintValidator,
     private traversalService: FlowTraversalService,
-    private treeQueries: ActivityTreeQueries
+    private treeQueries: ActivityTreeQueries,
   ) {}
 
   /**
@@ -37,7 +37,7 @@ export class ChoiceRequestHandler {
    */
   public handleChoice(
     targetActivityId: string,
-    currentActivity: Activity | null
+    currentActivity: Activity | null,
   ): SequencingResult {
     const result = new SequencingResult();
 
@@ -55,11 +55,9 @@ export class ChoiceRequestHandler {
     }
 
     // Validate choice constraints
-    const validation = this.constraintValidator.validateChoice(
-      currentActivity,
-      targetActivity,
-      { checkAvailability: true }
-    );
+    const validation = this.constraintValidator.validateChoice(currentActivity, targetActivity, {
+      checkAvailability: true,
+    });
 
     if (!validation.valid) {
       result.exception = validation.exception;
@@ -67,16 +65,16 @@ export class ChoiceRequestHandler {
     }
 
     // Find common ancestor
-    const commonAncestor = this.treeQueries.findCommonAncestor(
-      currentActivity,
-      targetActivity
-    );
+    const commonAncestor = this.treeQueries.findCommonAncestor(currentActivity, targetActivity);
 
-    // Terminate descendent attempts from common ancestor
+    // End the active path between the already-terminated current activity and
+    // the common ancestor, excluding both endpoints. Ending the common ancestor
+    // would make delivery start a new parent attempt and discard the tracking
+    // data that Choice is meant to preserve within that branch.
+    // @spec SCORM 2004 4th Ed. SN UP.3 Terminate Descendent Attempts Process
     if (currentActivity) {
-      this.terminateDescendentAttemptsProcess(
-        commonAncestor || this.activityTree.root!
-      );
+      const ancestor = commonAncestor || this.activityTree.root!;
+      this.terminateDescendentAttemptsProcess(currentActivity, ancestor);
     }
 
     // @spec SCORM 2004 SN 4th Ed. SB.2.9 steps 3-4: the root-to-target path
@@ -85,8 +83,7 @@ export class ChoiceRequestHandler {
     for (const pathActivity of this.treeQueries.getPathToRoot(targetActivity)) {
       const hiddenByRule = pathActivity.sequencingRules.preConditionRules.some(
         (rule) =>
-          rule.action === RuleActionType.HIDE_FROM_CHOICE &&
-          rule.evaluate(pathActivity) === true
+          rule.action === RuleActionType.HIDE_FROM_CHOICE && rule.evaluate(pathActivity) === true,
       );
       if (hiddenByRule) {
         result.exception = "SB.2.9-4";
@@ -213,10 +210,7 @@ export class ChoiceRequestHandler {
     const children = fromActivity.getAvailableChildren();
 
     // Validate children against constraints
-    const validChildren = this.constraintValidator.validateFlowConstraints(
-      fromActivity,
-      children
-    );
+    const validChildren = this.constraintValidator.validateFlowConstraints(fromActivity, children);
 
     if (!validChildren.valid) {
       return null;
@@ -242,7 +236,7 @@ export class ChoiceRequestHandler {
    */
   private enhancedChoiceTraversal(
     activity: Activity,
-    isBackwardTraversal: boolean = false
+    isBackwardTraversal: boolean = false,
   ): ChoiceTraversalResult {
     // Cannot walk backward from root
     if (isBackwardTraversal && activity === this.activityTree.root) {
@@ -296,13 +290,23 @@ export class ChoiceRequestHandler {
   }
 
   /**
-   * Terminate descendent attempts (simplified)
-   * @param {Activity} activity - The activity
+   * End active attempts on the path from current to common ancestor, exclusive.
+   * @param {Activity} currentActivity - The already-terminated current activity
+   * @param {Activity} commonAncestor - The ancestor whose attempt remains active
    */
-  private terminateDescendentAttemptsProcess(activity: Activity): void {
-    activity.isActive = false;
-    for (const child of activity.children) {
-      this.terminateDescendentAttemptsProcess(child);
+  private terminateDescendentAttemptsProcess(
+    currentActivity: Activity,
+    commonAncestor: Activity,
+  ): void {
+    if (currentActivity === commonAncestor) {
+      return;
+    }
+
+    let activity = currentActivity.parent;
+    while (activity && activity !== commonAncestor) {
+      const parent = activity.parent;
+      this.traversalService.endActiveAttempt(activity);
+      activity = parent;
     }
   }
 }

--- a/src/cmi/scorm2004/sequencing/overall_sequencing_process.ts
+++ b/src/cmi/scorm2004/sequencing/overall_sequencing_process.ts
@@ -67,7 +67,7 @@ export interface PreparedNavigationRequest {
   navigationRequest: NavigationRequestType;
   navResult: NavigationRequestResult;
   deliveryRequest: DeliveryRequest | null;
-  sessionEndReason: "exit_all" | "abandon_all" | null;
+  sessionEndReason: "exit_all" | "abandon_all" | "suspend_all" | null;
 }
 
 /**
@@ -358,7 +358,9 @@ export class OverallSequencingProcess {
             ? "exit_all"
             : navResult.terminationRequest === SequencingRequestType.ABANDON_ALL
               ? "abandon_all"
-              : null;
+              : navResult.terminationRequest === SequencingRequestType.SUSPEND_ALL
+                ? "suspend_all"
+                : null;
         return {
           navigationRequest,
           navResult,
@@ -390,6 +392,13 @@ export class OverallSequencingProcess {
     }
 
     if (prepared.sessionEndReason) {
+      if (prepared.sessionEndReason === "suspend_all") {
+        // SUSPEND_ALL ends the current session while retaining the suspended
+        // activity path for RESUME_ALL in the next session. The root pointer
+        // installed by TB.2.3 is only an intermediate sequencing state and
+        // would make RESUME_ALL fail its currentActivity == null precondition.
+        this.activityTree.setCurrentActivityWithoutActivation(null);
+      }
       this.fireEvent("onSequencingSessionEnd", {
         reason: prepared.sessionEndReason,
         navigationRequest,

--- a/src/cmi/scorm2004/sequencing/state/sequencing_state_manager.ts
+++ b/src/cmi/scorm2004/sequencing/state/sequencing_state_manager.ts
@@ -213,8 +213,26 @@ export class SequencingStateManager {
       if (state.currentActivity) {
         const currentActivity = this.activityTree.getActivity(state.currentActivity);
         if (currentActivity) {
-          this.activityTree.currentActivity = currentActivity;
-          currentActivity.isActive = true;
+          const currentActivityState = state.activityStates?.[state.currentActivity];
+          const isLegacySuspendedRootPointer =
+            currentActivity === this.activityTree.root &&
+            !!state.suspendedActivity &&
+            currentActivityState?.isActive === false &&
+            currentActivityState?.isSuspended === true;
+
+          // A pre-activityStates snapshot has no serialized flags to preserve, so retain the
+          // original setter behavior that activates the current activity and its ancestors.
+          if (isLegacySuspendedRootPointer) {
+            this.activityTree.setCurrentActivityWithoutActivation(null);
+          } else if (!state.activityStates) {
+            this.activityTree.currentActivity = currentActivity;
+            currentActivity.isActive = true;
+          } else {
+            // New snapshots must not reactivate an activity that was persisted as inactive,
+            // such as the suspended root after SUSPEND_ALL. Activity flags were restored above.
+            this.activityTree.setCurrentActivityWithoutActivation(currentActivity);
+            currentActivity.isActive = currentActivityState?.isActive ?? true;
+          }
         }
       }
 

--- a/src/cmi/scorm2004/sequencing/traversal/flow_traversal_service.ts
+++ b/src/cmi/scorm2004/sequencing/traversal/flow_traversal_service.ts
@@ -46,6 +46,22 @@ export class FlowTraversalService {
   }
 
   /**
+   * End one active attempt through the coordinator-owned UP.4 process.
+   * SequencingProcess can also be used without the overall coordinator in
+   * focused callers, so retain the state-only fallback for that case.
+   */
+  public endActiveAttempt(activity: Activity): void {
+    if (!activity.isActive) {
+      return;
+    }
+    if (this.endAttemptCallback) {
+      this.endAttemptCallback(activity);
+    } else {
+      activity.isActive = false;
+    }
+  }
+
+  /**
    * Flow Subprocess (SB.2.3)
    * Traverses the activity tree in the specified direction to find a deliverable activity
    * @param {Activity} fromActivity - The activity to flow from
@@ -219,10 +235,9 @@ export class FlowTraversalService {
     if (
       activity.parent &&
       activity.children.length > 0 &&
-      activity.isActive &&
-      this.endAttemptCallback
+      activity.isActive
     ) {
-      this.endAttemptCallback(activity);
+      this.endActiveAttempt(activity);
     }
   }
 

--- a/src/utilities/PlayerEventAdapter.ts
+++ b/src/utilities/PlayerEventAdapter.ts
@@ -303,10 +303,13 @@ export class PlayerEventAdapter {
     const reasonMap: Record<string, SessionEndReason> = {
       complete: "complete",
       suspend: "suspend",
+      suspend_all: "suspend",
       exit: "exit",
       exitAll: "exit",
+      exit_all: "exit",
       abandon: "abandon",
       abandonAll: "abandon",
+      abandon_all: "abandon",
     };
 
     const reason = reasonMap[data.reason] || "exit";

--- a/test/cmi/scorm2004/sequencing/asset_only_default_rollup.spec.ts
+++ b/test/cmi/scorm2004/sequencing/asset_only_default_rollup.spec.ts
@@ -37,15 +37,16 @@ describe("asset-only default rollup", () => {
       }
     }
     expect(sequencing!.getSequencingState().currentActivity?.id).toBe("asset-4-3");
-    expect(sequencing!.processNavigationRequest("choice", "asset-1-1")).toBe(true);
-    for (let index = 1; index < 18; index += 1) {
-      expect(sequencing!.processNavigationRequest("continue")).toBe(true);
-    }
-
-    expect(sequencing!.getSequencingState().currentActivity?.id).toBe("asset-4-3");
     expect(sequencing!.processNavigationRequest("continue")).toBe(true);
 
     const state = sequencing!.getSequencingState();
+    expect(state.rootActivity?.attemptCount).toBe(1);
+    expect(state.rootActivity?.children.map((child) => child.attemptCount)).toEqual([1, 1, 1, 1]);
+    expect(
+      state.rootActivity?.children.flatMap((cluster) =>
+        cluster.children.map((leaf) => [leaf.completionStatus, leaf.successStatus]),
+      ),
+    ).toEqual(Array.from({ length: 18 }, () => ["completed", "passed"]));
     expect(state.rootActivity?.children.map((child) => child.completionStatus)).toEqual([
       "completed",
       "completed",

--- a/test/cmi/scorm2004/sequencing/end_sequencing_session.spec.ts
+++ b/test/cmi/scorm2004/sequencing/end_sequencing_session.spec.ts
@@ -280,6 +280,34 @@ describe("EndSequencingSession Handling", () => {
       expect(delivery.exception).toBeNull();
     });
 
+    it("should report SUSPEND_ALL's implicit EXIT as suspend_all", () => {
+      activityTree.currentActivity = sco2;
+      sco2.isActive = true;
+      eventCallback.mockClear();
+
+      const prepared = overallProcess.prepareNavigationRequest(
+        NavigationRequestType.SUSPEND_ALL,
+      );
+
+      expect(prepared).not.toBeNull();
+      expect(prepared?.navResult.terminationRequest).toBe(SequencingRequestType.SUSPEND_ALL);
+      expect(prepared?.sessionEndReason).toBe("suspend_all");
+
+      const delivery = overallProcess.completeNavigationRequest(prepared!);
+
+      expect(delivery.valid).toBe(true);
+      expect(delivery.targetActivity).toBeNull();
+      expect(activityTree.currentActivity).toBeNull();
+      expect(activityTree.suspendedActivity).toBe(sco2);
+      expect(eventCallback).toHaveBeenCalledWith(
+        "onSequencingSessionEnd",
+        expect.objectContaining({
+          reason: "suspend_all",
+          navigationRequest: NavigationRequestType.SUSPEND_ALL,
+        }),
+      );
+    });
+
     it("should NOT fire onSequencingSessionEnd when session continues", () => {
       // Navigate to first activity
       overallProcess.processNavigationRequest(NavigationRequestType.START);

--- a/test/cmi/scorm2004/sequencing/overall_sequencing_process.spec.ts
+++ b/test/cmi/scorm2004/sequencing/overall_sequencing_process.spec.ts
@@ -708,8 +708,8 @@ describe("Overall Sequencing Process (OP.1)", () => {
         // Suspended activity reference should be set to current
         expect(activityTree.suspendedActivity).toBe(grandchild1);
 
-        // TB.2.3 5.6: Current activity should move to root
-        expect(activityTree.currentActivity).toBe(root);
+        // The root is only a transient TB.2.3 pointer; the ended session leaves no current activity.
+        expect(activityTree.currentActivity).toBeNull();
       });
 
       it("should suspend entire path for deeply nested activity (3+ levels)", () => {
@@ -761,7 +761,7 @@ describe("Overall Sequencing Process (OP.1)", () => {
         expect(level0.isActive).toBe(false);
 
         expect(deepTree.suspendedActivity).toBe(level4);
-        expect(deepTree.currentActivity).toBe(level0);
+        expect(deepTree.currentActivity).toBeNull();
       });
 
       it("should handle suspend when current activity is root (single element path)", () => {
@@ -777,7 +777,7 @@ describe("Overall Sequencing Process (OP.1)", () => {
         expect(root.isSuspended).toBe(true);
         expect(root.isActive).toBe(false);
         expect(activityTree.suspendedActivity).toBe(root);
-        expect(activityTree.currentActivity).toBe(root);
+        expect(activityTree.currentActivity).toBeNull();
       });
 
       it("should not affect sibling activities outside the path", () => {
@@ -817,7 +817,7 @@ describe("Overall Sequencing Process (OP.1)", () => {
         expect(child1.isSuspended).toBe(true);
         expect(root.isSuspended).toBe(true);
         expect(activityTree.suspendedActivity).toBe(grandchild1);
-        expect(activityTree.currentActivity).toBe(root);
+        expect(activityTree.currentActivity).toBeNull();
 
         // Simulate session termination and new session (Terminate/Initialize cycle)
         // During termination, currentActivity is cleared
@@ -3122,7 +3122,7 @@ describe("Overall Sequencing Process (OP.1)", () => {
 
         expect(state).toBeDefined();
         expect((state as any).activityTree).toBeDefined();
-        expect((state as any).currentActivityId).toBe(root.id);
+        expect((state as any).currentActivityId).toBeNull();
         expect((state as any).suspendedActivityId).toBe(grandchild1.id);
         expect((state as any).globalObjectives).toBeDefined();
         expect((state as any).timestamp).toBeDefined();
@@ -3179,7 +3179,7 @@ describe("Overall Sequencing Process (OP.1)", () => {
 
         overallProcess.restoreSuspensionState(state);
 
-        expect(activityTree.currentActivity?.id).toBe(root.id);
+        expect(activityTree.currentActivity).toBeNull();
         expect(activityTree.suspendedActivity?.id).toBe(grandchild1.id);
       });
 

--- a/test/cmi/scorm2004/sequencing/sequencing_requests.spec.ts
+++ b/test/cmi/scorm2004/sequencing/sequencing_requests.spec.ts
@@ -335,11 +335,14 @@ describe("Sequencing Request Processes (SB.2.5-2.11)", () => {
       expect(result.targetActivity).toBe(lesson2_1);
     });
 
-    it("should terminate descendants from common ancestor", () => {
+    it("should end only the active path below the common ancestor", () => {
       activityTree.currentActivity = lesson1_1;
       lesson1_1.isActive = false;
-      module1.isActive = true;
-      lesson1_2.isActive = true;
+      const endedActivities: string[] = [];
+      sequencingProcess.setEndAttemptCallback((activity) => {
+        endedActivities.push(activity.id);
+        activity.isActive = false;
+      });
 
       const result = sequencingProcess.sequencingRequestProcess(
         SequencingRequestType.CHOICE,
@@ -347,8 +350,11 @@ describe("Sequencing Request Processes (SB.2.5-2.11)", () => {
       );
 
       expect(result.deliveryRequest).toBe(DeliveryRequestType.DELIVER);
-      // Descendants should be terminated
-      expect(lesson1_2.isActive).toBe(false);
+      expect(endedActivities).toEqual(["module1"]);
+      expect(root.isActive).toBe(true);
+      expect(module1.isActive).toBe(false);
+      expect(module2.isActive).toBe(false);
+      expect(lesson2_1.isActive).toBe(false);
     });
   });
 

--- a/test/cmi/scorm2004/sequencing/state_persistence.spec.ts
+++ b/test/cmi/scorm2004/sequencing/state_persistence.spec.ts
@@ -689,11 +689,120 @@ describe("State Persistence (Multi-Session Support)", () => {
       expect(restoreResult).toBe(true);
 
       // Verify suspended state was restored correctly
+      expect(newActivityTree.currentActivity).toBeNull();
+      expect(newRoot.isActive).toBe(false);
+      expect(newRoot.isSuspended).toBe(true);
       expect(newActivityTree.suspendedActivity?.id).toBe("lesson1");
       expect(newLesson1.isSuspended).toBe(true);
 
       // The state is correctly restored - the suspended activity is available
-      // for a RESUME_ALL navigation request by the navigation process
+      // for a RESUME_ALL navigation request by the navigation process.
+      const resumeResult = newOverallProcess.processNavigationRequest(
+        NavigationRequestType.RESUME_ALL,
+      );
+      expect(resumeResult.valid).toBe(true);
+      expect(resumeResult.targetActivity).toBe(newLesson1);
+      expect(newActivityTree.currentActivity).toBe(newLesson1);
+      expect(newLesson1.isSuspended).toBe(false);
+    });
+
+    it("should clear a legacy suspended-root pointer before RESUME_ALL", () => {
+      overallProcess.processNavigationRequest(NavigationRequestType.START);
+      overallProcess.processNavigationRequest(NavigationRequestType.SUSPEND_ALL);
+
+      const state = overallProcess.getSequencingState();
+      // Older SUSPEND_ALL snapshots retained the transient root pointer.
+      state.currentActivity = "root";
+
+      const newActivityTree = new ActivityTree();
+      const newRoot = new Activity("root", "Course");
+      const newModule1 = new Activity("module1", "Module 1");
+      const newLesson1 = new Activity("lesson1", "Lesson 1");
+      const newLesson2 = new Activity("lesson2", "Lesson 2");
+      const newModule2 = new Activity("module2", "Module 2");
+      const newLesson3 = new Activity("lesson3", "Lesson 3");
+      newRoot.addChild(newModule1);
+      newRoot.addChild(newModule2);
+      newModule1.addChild(newLesson1);
+      newModule1.addChild(newLesson2);
+      newModule2.addChild(newLesson3);
+      newActivityTree.root = newRoot;
+      newRoot.sequencingControls.flow = true;
+      newModule1.sequencingControls.flow = true;
+      newModule2.sequencingControls.flow = true;
+
+      const newOverallProcess = new OverallSequencingProcess(
+        newActivityTree,
+        new SequencingProcess(newActivityTree),
+        new RollupProcess(),
+        new ADLNav()
+      );
+
+      expect(newOverallProcess.restoreSequencingState(state)).toBe(true);
+      expect(newActivityTree.currentActivity).toBeNull();
+      expect(newActivityTree.suspendedActivity).toBe(newLesson1);
+
+      const resumeResult = newOverallProcess.processNavigationRequest(
+        NavigationRequestType.RESUME_ALL,
+      );
+      expect(resumeResult.valid).toBe(true);
+      expect(resumeResult.targetActivity).toBe(newLesson1);
+    });
+
+    it("should preserve an ordinary inactive current activity", () => {
+      overallProcess.processNavigationRequest(NavigationRequestType.START);
+      lesson1.isActive = false;
+
+      const state = overallProcess.getSequencingState();
+
+      const newActivityTree = new ActivityTree();
+      const newRoot = new Activity("root", "Course");
+      const newModule1 = new Activity("module1", "Module 1");
+      const newLesson1 = new Activity("lesson1", "Lesson 1");
+      newRoot.addChild(newModule1);
+      newModule1.addChild(newLesson1);
+      newActivityTree.root = newRoot;
+      newRoot.sequencingControls.flow = true;
+      newModule1.sequencingControls.flow = true;
+
+      const newOverallProcess = new OverallSequencingProcess(
+        newActivityTree,
+        new SequencingProcess(newActivityTree),
+        new RollupProcess(),
+        new ADLNav()
+      );
+
+      expect(newOverallProcess.restoreSequencingState(state)).toBe(true);
+      expect(newActivityTree.currentActivity).toBe(newLesson1);
+      expect(newLesson1.isActive).toBe(false);
+    });
+
+    it("should retain legacy current-pointer activation without activityStates", () => {
+      overallProcess.processNavigationRequest(NavigationRequestType.START);
+
+      const state = overallProcess.getSequencingState();
+      delete (state as Partial<typeof state>).activityStates;
+
+      const newActivityTree = new ActivityTree();
+      const newRoot = new Activity("root", "Course");
+      const newModule1 = new Activity("module1", "Module 1");
+      const newLesson1 = new Activity("lesson1", "Lesson 1");
+      newRoot.addChild(newModule1);
+      newModule1.addChild(newLesson1);
+      newActivityTree.root = newRoot;
+
+      const newOverallProcess = new OverallSequencingProcess(
+        newActivityTree,
+        new SequencingProcess(newActivityTree),
+        new RollupProcess(),
+        new ADLNav()
+      );
+
+      expect(newOverallProcess.restoreSequencingState(state)).toBe(true);
+      expect(newActivityTree.currentActivity).toBe(newLesson1);
+      expect(newLesson1.isActive).toBe(true);
+      expect(newModule1.isActive).toBe(true);
+      expect(newRoot.isActive).toBe(true);
     });
   });
 

--- a/test/cmi/scorm2004/sequencing/termination_request_process.spec.ts
+++ b/test/cmi/scorm2004/sequencing/termination_request_process.spec.ts
@@ -178,8 +178,8 @@ describe("Termination Request Process (TB.2.3)", () => {
       expect(child1.isSuspended).toBe(true);
       expect(root.isSuspended).toBe(true);
       expect(activityTree.suspendedActivity).toBe(grandchild1);
-      // Per TB.2.3 5.6, current activity is set to root
-      expect(activityTree.currentActivity).toBe(root);
+      // The root is only a transient TB.2.3 pointer; the ended session leaves no current activity.
+      expect(activityTree.currentActivity).toBeNull();
     });
 
     it("should suspend root when it is current activity", () => {
@@ -193,7 +193,7 @@ describe("Termination Request Process (TB.2.3)", () => {
       expect(root.isSuspended).toBe(true);
       expect(root.isActive).toBe(false);
       expect(activityTree.suspendedActivity).toBe(root);
-      expect(activityTree.currentActivity).toBe(root);
+      expect(activityTree.currentActivity).toBeNull();
     });
   });
 
@@ -435,8 +435,8 @@ describe("Termination Request Process (TB.2.3)", () => {
       expect(child1.isSuspended).toBe(true);
       expect(root.isSuspended).toBe(true);
       expect(activityTree.suspendedActivity).toBe(grandchild1);
-      // Per TB.2.3 5.6: current activity set to root
-      expect(activityTree.currentActivity).toBe(root);
+      // The root is only a transient TB.2.3 pointer; the ended session leaves no current activity.
+      expect(activityTree.currentActivity).toBeNull();
     });
 
     it("should clear suspended state when resuming different activity", () => {
@@ -784,7 +784,7 @@ describe("Termination Request Process (TB.2.3)", () => {
       expect(child1.isSuspended).toBe(true);
       expect(root.isSuspended).toBe(true);
       expect(activityTree.suspendedActivity).toBe(greatGrandchild);
-      expect(activityTree.currentActivity).toBe(root);
+      expect(activityTree.currentActivity).toBeNull();
     });
 
     it("should preserve activity attempt data during SUSPEND_ALL", () => {

--- a/test/utilities/PlayerEventAdapter.spec.ts
+++ b/test/utilities/PlayerEventAdapter.spec.ts
@@ -498,6 +498,14 @@ describe("PlayerEventAdapter", () => {
         expect(callbacks.onSessionEnd).toHaveBeenCalledWith("suspend", expect.any(Object));
       });
 
+      it("should normalize suspend_all to suspend reason", () => {
+        adapter.handleSequencingSessionEnd({
+          reason: "suspend_all",
+        });
+
+        expect(callbacks.onSessionEnd).toHaveBeenCalledWith("suspend", expect.any(Object));
+      });
+
       it("should emit session end with exit reason", () => {
         adapter.handleSequencingSessionEnd({
           reason: "exit",
@@ -514,6 +522,14 @@ describe("PlayerEventAdapter", () => {
         expect(callbacks.onSessionEnd).toHaveBeenCalledWith("exit", expect.any(Object));
       });
 
+      it("should normalize exit_all to exit reason", () => {
+        adapter.handleSequencingSessionEnd({
+          reason: "exit_all",
+        });
+
+        expect(callbacks.onSessionEnd).toHaveBeenCalledWith("exit", expect.any(Object));
+      });
+
       it("should emit session end with abandon reason", () => {
         adapter.handleSequencingSessionEnd({
           reason: "abandon",
@@ -525,6 +541,14 @@ describe("PlayerEventAdapter", () => {
       it("should handle abandonAll as abandon reason", () => {
         adapter.handleSequencingSessionEnd({
           reason: "abandonAll",
+        });
+
+        expect(callbacks.onSessionEnd).toHaveBeenCalledWith("abandon", expect.any(Object));
+      });
+
+      it("should normalize abandon_all to abandon reason", () => {
+        adapter.handleSequencingSessionEnd({
+          reason: "abandon_all",
         });
 
         expect(callbacks.onSessionEnd).toHaveBeenCalledWith("abandon", expect.any(Object));


### PR DESCRIPTION
## Summary

- preserve the suspended activity path across session state persistence so Resume All can deliver it after relaunch
- normalize snake-case session-end reasons through the player event adapter, including legacy suspended-root snapshots
- implement the SCORM 2004 UP.3 Choice path correctly by ending only active intermediate attempts below the common ancestor
- retain the common ancestor attempt so Choice navigation does not erase completed sibling tracking or break final rollup

The Choice behavior follows the 1EdTech SCORM 2004 4th Edition Terminate Descendent Attempts Process (UP.3): https://www.imsglobal.org/node/52621#UP.3

## Testing

- `npm test`: 199 files, 6,952 tests passed
- `npm run lint`: passed
- `npm run build:all`: ES5 and declaration builds passed
- browser integration matrix across six sequencing fixtures: every Firefox case passed; 2 Chromium `page.goto` timeouts from the overloaded full run passed on isolated retry (4/4 browser cases)
- live Phoenix share UAT: all 11 packages in the sequenced-module directory uploaded, validated, registered, and launched through the LMS/live S3 path
- live asset-only package: Choice traversal across all 18 leaves now persists Completed/Passed at the course level
- live Suspend All/Exit relaunch and sequenced navigation scenarios passed